### PR TITLE
Implement fee breakdown and tx summary

### DIFF
--- a/apps/web/src/components/offramp/OfframpQuoteModal.tsx
+++ b/apps/web/src/components/offramp/OfframpQuoteModal.tsx
@@ -5,16 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Loader2, X } from "lucide-react";
 
 import type { CreateOfframpResponse, OfframpFormState, BridgeFeeBreakdown } from "@/types/offramp";
-
-// Currency symbols
-const CURRENCY_SYMBOLS: Record<string, string> = {
-    NGN: "₦",
-    GHS: "₵",
-    KES: "KSh ",
-};
-
-const getCurrencySymbol = (currency: string) =>
-    CURRENCY_SYMBOLS[currency] || currency + " ";
+import { getCurrencySymbol } from "@/types/offramp";
 
 interface OfframpQuoteModalProps {
     isOpen: boolean;
@@ -80,42 +71,52 @@ export default function OfframpQuoteModal({
                 </h3>
 
                 <div className="space-y-4">
-                    {/* Amount Section */}
                     <div className="bg-fundable-dark p-4 rounded-lg">
-                        <p className="text-fundable-light-grey text-sm">You Send (Stellar)</p>
-                        <p className="text-white text-xl font-semibold">
-                            {parseFloat(feeBreakdown.sendAmount).toFixed(4)} {formState.token}
-                        </p>
-                    </div>
-
-                    <div className="bg-fundable-dark p-4 rounded-lg">
-                        <p className="text-fundable-light-grey text-sm">You Receive</p>
-                        <p className="text-white text-xl font-semibold">
+                        <p className="text-fundable-light-grey text-sm">Total Payout</p>
+                        <p className="text-white text-2xl font-bold">
                             {currencySymbol}{offrampData.fiatAmount.toLocaleString()}
                         </p>
                     </div>
 
-                    {/* Details */}
-                    <div className="space-y-3 text-sm">
+                    {/* Details Breakdown */}
+                    <div className="space-y-3 bg-fundable-dark/50 p-4 rounded-lg border border-gray-800 text-sm">
+                        <div className="flex justify-between items-center text-xs text-fundable-light-grey uppercase tracking-wider mb-1">
+                            <span>Transaction Breakdown</span>
+                        </div>
                         <div className="flex justify-between">
-                            <span className="text-fundable-light-grey">Bridge Fee (Allbridge)</span>
+                            <span className="text-fundable-light-grey">Initial Send (Stellar)</span>
                             <span className="text-white">
-                                {feeBreakdown.bridgeFee} {formState.token}
+                                {parseFloat(feeBreakdown.sendAmount).toFixed(4)} {formState.token}
                             </span>
                         </div>
+                        <div className="flex justify-between">
+                            <span className="text-fundable-light-grey">Bridge Fee (Allbridge)</span>
+                            <span className="text-red-400">
+                                -{feeBreakdown.bridgeFee} {formState.token}
+                            </span>
+                        </div>
+                        <div className="flex justify-between">
+                            <span className="text-fundable-light-grey">Received on Polygon</span>
+                            <span className="text-white">
+                                {feeBreakdown.receivedOnPolygon} {formState.token}
+                            </span>
+                        </div>
+                        <div className="h-px bg-gray-800 my-1" />
                         <div className="flex justify-between">
                             <span className="text-fundable-light-grey">Exchange Rate</span>
                             <span className="text-white">
-                                {feeBreakdown.exchangeRate}
+                                1 {formState.token} = {getCurrencySymbol(feeBreakdown.currency)}{feeBreakdown.exchangeRate}
                             </span>
                         </div>
-                        <div className="flex justify-between">
-                            <span className="text-fundable-light-grey">Estimated Time</span>
-                            <span className="text-fundable-purple">~{feeBreakdown.estimatedTime} minutes</span>
+                        <div className="flex justify-between items-center">
+                            <span className="text-fundable-light-grey">Est. Processing Time</span>
+                            <div className="flex items-center gap-1.5 text-fundable-purple">
+                                <span className="font-medium">~{feeBreakdown.estimatedTime} minutes</span>
+                            </div>
                         </div>
-                        <div className="flex justify-between">
+                        <div className="flex justify-between items-center">
                             <span className="text-fundable-light-grey">Reference</span>
-                            <span className="text-white text-xs font-mono">{offrampData.reference}</span>
+                            <span className="text-white text-[10px] font-mono opacity-80">{offrampData.reference}</span>
                         </div>
                     </div>
 

--- a/apps/web/src/components/offramp/OfframpSuccessModal.tsx
+++ b/apps/web/src/components/offramp/OfframpSuccessModal.tsx
@@ -5,6 +5,7 @@ import { CheckCircle2, Copy, ExternalLink, X, Loader2, XCircle, Clock } from "lu
 import { Button } from "@/components/ui/button";
 import toast from "react-hot-toast";
 import type { QuoteStatusData, BridgeFeeBreakdown } from "@/types/offramp";
+import { getCurrencySymbol } from "@/types/offramp";
 
 interface OfframpSuccessModalProps {
     isOpen: boolean;
@@ -96,6 +97,9 @@ export default function OfframpSuccessModal({
                 {/* Summary Card */}
                 {feeBreakdown && (
                     <div className="space-y-4 p-5 rounded-2xl bg-fundable-dark border border-gray-800">
+                        <div className="flex justify-between items-center text-xs text-fundable-light-grey uppercase tracking-wider mb-1">
+                            <span>Transaction Summary</span>
+                        </div>
                         <div className="flex justify-between items-center text-sm">
                             <span className="text-fundable-light-grey">Initial Send</span>
                             <span className="text-white font-medium">
@@ -108,11 +112,26 @@ export default function OfframpSuccessModal({
                                 -{parseFloat(feeBreakdown.bridgeFee).toFixed(4)} USDC
                             </span>
                         </div>
+                        {feeBreakdown.cashwyreFee && parseFloat(feeBreakdown.cashwyreFee) > 0 && (
+                            <div className="flex justify-between items-center text-sm">
+                                <span className="text-fundable-light-grey">Provider Fee</span>
+                                <span className="text-red-400">
+                                    -{parseFloat(feeBreakdown.cashwyreFee).toFixed(2)} {payoutStatus?.id.split("-")[0].toUpperCase() === "NG" ? "NGN" : "Fiat"}
+                                </span>
+                            </div>
+                        )}
+                        <div className="flex justify-between items-center text-sm border-t border-gray-800/50 pt-3 mt-1">
+                            <span className="text-fundable-light-grey">Exchange Rate</span>
+                            <span className="text-white">
+                                1 USDC = {getCurrencySymbol(feeBreakdown.currency)}{feeBreakdown.exchangeRate}
+                            </span>
+                        </div>
                         <div className="h-px bg-gray-800" />
                         <div className="flex justify-between items-center">
                             <span className="text-sm font-medium text-white">Total Received</span>
                             <span className="text-xl font-bold text-green-500">
-                                ₦{parseFloat(feeBreakdown.fiatPayout).toLocaleString()}
+                                {getCurrencySymbol(feeBreakdown.currency)}
+                                {parseFloat(feeBreakdown.fiatPayout).toLocaleString()}
                             </span>
                         </div>
                     </div>

--- a/apps/web/src/components/offramp/OfframpSummary.tsx
+++ b/apps/web/src/components/offramp/OfframpSummary.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
 
 import type { OfframpFormState, ProviderRate } from "@/types/offramp";
-import { SUPPORTED_COUNTRIES } from "@/types/offramp";
+import { SUPPORTED_COUNTRIES, getCurrencySymbol } from "@/types/offramp";
 
 interface OfframpSummaryProps {
     formState: OfframpFormState;
@@ -99,9 +99,7 @@ export default function OfframpSummary({
                             {quote ? (
                                 <>
                                     <p className="text-2xl font-bold text-white">
-                                        {selectedCountry?.currency === "NGN" ? "₦" :
-                                            selectedCountry?.currency === "GHS" ? "₵" :
-                                                selectedCountry?.currency === "KES" ? "KSh " : ""}
+                                        {getCurrencySymbol(selectedCountry?.currency || "")}
                                         {quote.fiatAmount?.toLocaleString()}
                                     </p>
                                     <p className="text-fundable-light-grey text-xs">

--- a/apps/web/src/hooks/useOfframpBridge.ts
+++ b/apps/web/src/hooks/useOfframpBridge.ts
@@ -281,7 +281,8 @@ export function useOfframpBridge(): UseOfframpBridgeReturn {
                     receivedOnPolygon: depositAmount,
                     cashwyreFee: (offrampRes.data.depositAmount - offrampRes.data.fiatAmount / ratePerUSDC).toFixed(2),
                     fiatPayout: offrampRes.data.fiatAmount.toString(),
-                    exchangeRate: `1 USDC = ${ratePerUSDC.toFixed(2)} ${currency}`,
+                    currency,
+                    exchangeRate: ratePerUSDC.toFixed(2),
                     estimatedTime: quoteResult.estimatedTimeMinutes + 5,
                 });
 

--- a/apps/web/src/types/offramp.ts
+++ b/apps/web/src/types/offramp.ts
@@ -5,6 +5,16 @@
 export type OfframpCountry = "NG" | "GH" | "KE";
 export type OfframpCurrency = "NGN" | "GHS" | "KES";
 
+// Currency symbols
+export const CURRENCY_SYMBOLS: Record<string, string> = {
+    NGN: "₦",
+    GHS: "₵",
+    KES: "KSh ",
+};
+
+export const getCurrencySymbol = (currency: string) =>
+    CURRENCY_SYMBOLS[currency] || currency + " ";
+
 export interface CountryInfo {
     code: OfframpCountry;
     name: string;
@@ -181,6 +191,8 @@ export interface BridgeFeeBreakdown {
     cashwyreFee: string;
     /** Final fiat payout amount */
     fiatPayout: string;
+    /** Currency code (e.g., NGN) */
+    currency: string;
     /** USDC→fiat exchange rate */
     exchangeRate: string;
     /** Estimated time in minutes for bridge + payout */


### PR DESCRIPTION
## Summary
This PR implements detailed fee transparency and transaction summaries for the Offramp flow, addressing the requirement for clear cost breakdown before and after transaction execution.

## Changes
- **Detailed Fee Breakdown**: Updated OfframpQuoteModal to show a comprehensive breakdown including bridge fees, received amounts on Polygon, and estimated processing time.
- **Transaction Summary**: Enhanced OfframpSuccessModal with a summary card detailing the final transaction stats (sent, fees, exchange rate, and received).
- **Architecture Refactor**: 
  - Centralized currency symbol logic in types/offramp.ts.
  - Added `currency` field to BridgeFeeBreakdown for safer UI rendering.
  - Standardized `exchangeRate` to numeric strings for flexible component formatting.

## Acceptance Criteria Verified
- [x] Users see a transparent cost breakdown before confirming (Quote Modal).
- [x] Completed transactions show a clear summary of what was sent and received (Success Modal).
- [x] Estimated processing time is clearly visible before confirmation.

## Related Issues
Closes #62 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Transaction Breakdown" card displaying detailed fee breakdown including send amount, bridge fee, received amount, and exchange rate.
  * Added conditional Provider Fee display in success confirmation.

* **Style**
  * Redesigned quote modal with improved "Total Payout" display.
  * Enhanced currency symbol handling for consistency across offramp flows.
  * Updated "Est. Processing Time" label and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->