### PR TITLE
added 404-route-404

### DIFF
--- a/apps/web/src/app/(overview)/distribution/page.tsx
+++ b/apps/web/src/app/(overview)/distribution/page.tsx
@@ -10,6 +10,7 @@ import { Switch } from '@/components/ui/switch';
 import { Upload, Plus, Trash2 } from 'lucide-react';
 import { useDistributionState } from '@/hooks/use-distribution-state';
 import { downloadCSVTemplate, processCSVFile } from '@/utils/csv-processing';
+import ProtectedRoute from '@/components/layouts/ProtectedRoute';
 
 export default function DistributionPage() {
   const {
@@ -152,11 +153,12 @@ export default function DistributionPage() {
   };
 
   return (
-    <div 
-      ref={pageRef}
-      className="h-screen mt-10 bg-black text-white overflow-y-auto scroll-smooth distribution-scrollbar"
-    >
-      <div className="max-w-6xl mx-auto p-6 pb-12">
+    <ProtectedRoute description="Connect your Stellar wallet to create token distributions.">
+      <div 
+        ref={pageRef}
+        className="h-screen mt-10 bg-black text-white overflow-y-auto scroll-smooth distribution-scrollbar"
+      >
+        <div className="max-w-6xl mx-auto p-6 pb-12">
         {/* Header */}
         <h1 className="text-xl font-semibold mb-8 text-zinc-100">Create Distribution</h1>
 
@@ -387,7 +389,8 @@ export default function DistributionPage() {
             Distribute Token
           </Button>
         </div>
+        </div>
       </div>
-    </div>
+    </ProtectedRoute>
   );
 }

--- a/apps/web/src/app/(overview)/history/page.tsx
+++ b/apps/web/src/app/(overview)/history/page.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useWallet } from "@/providers/StellarWalletProvider";
 import DashboardLayout from "@/components/layouts/DashboardLayout";
+import { ConnectWalletPrompt } from "@/components/layouts/ProtectedRoute";
 import HistoryTable from "@/components/modules/history/HistoryTable";
 import HistoryTableSkeleton from "@/components/modules/history/HistoryTableSkeleton";
 import { columns } from "@/components/modules/history/columns";
@@ -74,12 +75,11 @@ const HistoryPage = () => {
         <DashboardLayout title="Transaction History">
             <div className="py-6 space-y-6">
                 {!address ? (
-                    <div className="flex h-[400px] flex-col items-center justify-center rounded-xl border border-zinc-800 bg-zinc-900/50 p-8 text-center">
-                        <h2 className="text-xl font-semibold mb-2">Connect your wallet</h2>
-                        <p className="text-zinc-400 max-w-md">
-                            Please connect your Stellar wallet to view your transaction history across payment streams and distributions.
-                        </p>
-                    </div>
+                    <ConnectWalletPrompt
+                        title="Connect your wallet"
+                        description="Please connect your Stellar wallet to view your transaction history across payment streams and distributions."
+                        containerClassName="min-h-[400px]"
+                    />
                 ) : (
                     <>
                         <div className="flex items-center gap-4">

--- a/apps/web/src/app/(overview)/offramp/page.tsx
+++ b/apps/web/src/app/(overview)/offramp/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useState } from "react";
-import { useWallet } from "@/providers/StellarWalletProvider";
 import { useOfframpBridge } from "@/hooks/useOfframpBridge";
 import { OfframpForm } from "@/components/offramp/OfframpForm";
 import BankDetailsCard from "@/components/offramp/BankDetailsCard";
@@ -9,11 +8,10 @@ import OfframpSummary from "@/components/offramp/OfframpSummary";
 import OfframpQuoteModal from "@/components/offramp/OfframpQuoteModal";
 import { BridgeStatusTracker } from "@/components/offramp/BridgeStatusTracker";
 import OfframpSuccessModal from "@/components/offramp/OfframpSuccessModal";
-import { Loader2 } from "lucide-react";
 import DashboardLayout from "@/components/layouts/DashboardLayout";
+import ProtectedRoute from "@/components/layouts/ProtectedRoute";
 
 export default function OfframpPage() {
-    const { address, isConnected, openModal } = useWallet();
     const {
         step,
         error,
@@ -75,62 +73,16 @@ export default function OfframpPage() {
                 showOnNetwork: "testnet"
             }}
         >
-            <div className="space-y-8 pb-10">
-                {/* Intro text */}
-                <p className="text-fundable-light-grey max-w-2xl px-2">
-                    Withdraw Stellar USDC instantly to your bank account in Nigeria, Ghana, or Kenya.
-                </p>
+            <ProtectedRoute
+                description="Connect your Stellar wallet to convert USDC to local currency."
+            >
+                <div className="space-y-8 pb-10">
+                    {/* Intro text */}
+                    <p className="text-fundable-light-grey max-w-2xl px-2">
+                        Withdraw Stellar USDC instantly to your bank account in Nigeria, Ghana, or Kenya.
+                    </p>
 
-                {/* Wallet Connection Prompt */}
-                {!isConnected && (
-                    <div className="max-w-xl mx-auto rounded-3xl border border-white/10 bg-fundable-mid-dark p-12 text-center space-y-6">
-                        <div className="w-20 h-20 rounded-full bg-white/5 mx-auto flex items-center justify-center">
-                            <svg
-                                width="32"
-                                height="32"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                className="text-fundable-purple"
-                            >
-                                <path
-                                    d="M21 12V7H5a2 2 0 010-4h14v4"
-                                    stroke="currentColor"
-                                    strokeWidth="2"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                />
-                                <path
-                                    d="M3 5v14a2 2 0 002 2h16v-5"
-                                    stroke="currentColor"
-                                    strokeWidth="2"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                />
-                                <path
-                                    d="M18 12a1 1 0 100 2 1 1 0 000-2z"
-                                    fill="currentColor"
-                                />
-                            </svg>
-                        </div>
-                        <div>
-                            <h3 className="text-2xl font-bold text-white mb-2">
-                                Connect Wallet
-                            </h3>
-                            <p className="text-fundable-light-grey">
-                                Please connect your Stellar wallet to use the offramp feature.
-                            </p>
-                        </div>
-                        <button
-                            onClick={openModal}
-                            className="px-8 py-4 rounded-xl font-bold text-fundable-dark bg-gradient-to-r from-fundable-purple-2 to-purple-500 hover:opacity-90 transition-all active:scale-95"
-                        >
-                            Connect Stellar Wallet
-                        </button>
-                    </div>
-                )}
-
-                {/* Main Content */}
-                {isConnected && (
+                    {/* Main Content */}
                     <div className="space-y-8">
                         {/* Error Banner */}
                         {error && !["signing", "bridging", "processing", "failed"].includes(step) && (
@@ -208,8 +160,8 @@ export default function OfframpPage() {
                             </div>
                         )}
                     </div>
-                )}
-            </div>
+                </div>
+            </ProtectedRoute>
 
             {/* Modals outside scroll area */}
             <OfframpQuoteModal

--- a/apps/web/src/app/(overview)/payment-stream/page.tsx
+++ b/apps/web/src/app/(overview)/payment-stream/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense } from "react";
 import DashboardLayout from "@/components/layouts/DashboardLayout";
+import ProtectedRoute from "@/components/layouts/ProtectedRoute";
 import CreatePaymentStream from "@/components/modules/payment-stream/CreatePaymentStream";
 import StreamsHistory from "@/components/modules/payment-stream/StreamsHistory";
 import StreamsTableSkeleton from "@/components/modules/payment-stream/StreamsTableSkeleton";
@@ -19,10 +20,14 @@ const PaymentStreamPage = () => {
                 showOnNetwork: "mainnet",
             }}
         >
-            <CreatePaymentStream />
-            <Suspense fallback={<StreamsTableSkeleton />}>
-                <StreamsHistory />
-            </Suspense>
+            <ProtectedRoute
+                description="Connect your Stellar wallet to create and manage payment streams."
+            >
+                <CreatePaymentStream />
+                <Suspense fallback={<StreamsTableSkeleton />}>
+                    <StreamsHistory />
+                </Suspense>
+            </ProtectedRoute>
         </DashboardLayout>
     );
 };

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,41 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-[70vh] items-center justify-center px-6 py-12">
+      <div className="relative w-full max-w-2xl overflow-hidden rounded-3xl border border-white/10 bg-fundable-mid-dark p-10 text-center shadow-[0_0_50px_rgba(130,86,255,0.15)]">
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-fundable-purple-2/20 via-transparent to-white/5" />
+        <div className="relative z-10 space-y-6">
+          <div className="flex items-center justify-center">
+            <Image
+              src="/fundable_logo.svg"
+              alt="Fundable"
+              width={140}
+              height={32}
+              priority
+            />
+          </div>
+          <div className="space-y-2">
+            <p className="text-sm uppercase tracking-[0.3em] text-fundable-light-grey">
+              404 Error
+            </p>
+            <h1 className="text-3xl font-semibold text-white">
+              We couldn&apos;t find that page
+            </h1>
+            <p className="text-fundable-light-grey">
+              The link may be outdated or the page might have moved. You can head back to the dashboard to keep building.
+            </p>
+          </div>
+          <div className="flex items-center justify-center gap-3">
+            <Button asChild variant="gradient" size="lg">
+              <Link href="/dashboard">Back to Dashboard</Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layouts/ProtectedRoute.tsx
+++ b/apps/web/src/components/layouts/ProtectedRoute.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import React, { type ReactNode } from "react";
+import { Wallet } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useWallet } from "@/providers/StellarWalletProvider";
+
+interface ConnectWalletPromptProps {
+  title?: string;
+  description?: string;
+  actionLabel?: string;
+  containerClassName?: string;
+  cardClassName?: string;
+}
+
+export function ConnectWalletPrompt({
+  title = "Connect your wallet to continue",
+  description = "You'll need a Stellar wallet connected to use this feature.",
+  actionLabel = "Connect Wallet",
+  containerClassName,
+  cardClassName,
+}: ConnectWalletPromptProps) {
+  const { openModal } = useWallet();
+
+  return (
+    <div
+      className={cn(
+        "flex min-h-[60vh] items-center justify-center px-4 py-10",
+        containerClassName,
+      )}
+    >
+      <div
+        className={cn(
+          "relative w-full max-w-xl overflow-hidden rounded-3xl border border-white/10 bg-fundable-mid-dark p-10 text-center shadow-[0_0_40px_rgba(130,86,255,0.12)]",
+          cardClassName,
+        )}
+      >
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/5 via-transparent to-fundable-purple-2/10" />
+        <div className="relative z-10 space-y-6">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full border border-white/10 bg-white/5">
+            <Wallet className="h-7 w-7 text-fundable-purple-2" />
+          </div>
+          <div className="space-y-2">
+            <h2 className="text-2xl font-semibold text-white">{title}</h2>
+            <p className="text-fundable-light-grey">{description}</p>
+          </div>
+          <Button variant="gradient" size="lg" onClick={openModal}>
+            {actionLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface ProtectedRouteProps extends ConnectWalletPromptProps {
+  children: ReactNode;
+}
+
+export default function ProtectedRoute({
+  children,
+  title,
+  description,
+  actionLabel,
+  containerClassName,
+  cardClassName,
+}: ProtectedRouteProps) {
+  const { address } = useWallet();
+
+  if (!address) {
+    return (
+      <ConnectWalletPrompt
+        title={title}
+        description={description}
+        actionLabel={actionLabel}
+        containerClassName={containerClassName}
+        cardClassName={cardClassName}
+      />
+    );
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
closes #55 
This PR adds a global custom 404 page that matches the dark theme and includes branding + “Back to Dashboard”.
Introduced a reusable ProtectedRoute with a centered “Connect your wallet to continue” card and connect button.
Wrapped the protected pages (payment-stream, distribution, offramp) with ProtectedRoute.
Updated History to use the same connect prompt for unconnected users.


[Screencast from 2026-03-24 20-25-29.webm](https://github.com/user-attachments/assets/827c921c-4c2c-4ba1-bf08-b5aed2299da4)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a 404 error page with navigation back to the dashboard.

* **Bug Fixes & Improvements**
  * Implemented consistent wallet-connection requirements across Distribution, History, Offramp, and Payment Stream pages.
  * Unified wallet-prompt UI for improved user experience and clearer guidance to connect a Stellar wallet before accessing protected features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->