### PR TITLE
fix: add stream end-time validation to prevent past-date submissions

### DIFF
--- a/apps/web/src/components/modules/payment-stream/CreatePaymentStream.tsx
+++ b/apps/web/src/components/modules/payment-stream/CreatePaymentStream.tsx
@@ -11,6 +11,7 @@ import { PaymentStreamConfirmationModal } from "./PaymentStreamConfirmationModal
 import { capitalizeWord } from "@/lib/utils";
 import { SUPPORTED_TOKENS, PaymentStreamFormData } from "@/lib/validations";
 import { StellarService } from "@/lib/stellar";
+import { validateEndTime } from "@/lib/stream-validation";
 
 // Stream form state type
 interface StreamFormData {
@@ -83,6 +84,13 @@ const CreatePaymentStream = () => {
         }
         if (!streamData.durationValue || parseInt(streamData.durationValue) <= 0) {
             toast.error("Duration must be greater than 0");
+            return;
+        }
+
+        // Validate end time
+        const endTimeError = validateEndTime(null, streamData.durationValue, streamData.duration);
+        if (endTimeError) {
+            toast.error(endTimeError);
             return;
         }
 

--- a/apps/web/src/components/modules/payment-stream/PaymentStreamForm.tsx
+++ b/apps/web/src/components/modules/payment-stream/PaymentStreamForm.tsx
@@ -1,10 +1,18 @@
 "use client";
 
+import { useMemo } from "react";
 import AppSelect from "@/components/molecules/AppSelect";
 import InputWithLabel from "@/components/molecules/InputWithLabel";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Loader2, Lock } from "lucide-react";
+import { Loader2, Lock, AlertCircle, Calendar } from "lucide-react";
+import {
+  validateEndTime,
+  calculateEndTime,
+  formatEndTime,
+  getRelativeTime,
+  type DurationUnit,
+} from "@/lib/stream-validation";
 
 interface StreamFormData {
   name: string;
@@ -45,6 +53,33 @@ export function PaymentStreamForm({
   ) => {
     setStreamData((prev) => ({ ...prev, [key]: value }));
   };
+
+  // Validate end time
+  const endTimeValidation = useMemo(() => {
+    if (!streamData.durationValue || !streamData.duration) {
+      return { isValid: true, error: null, endTime: null, relativeTime: null };
+    }
+
+    const error = validateEndTime(null, streamData.durationValue, streamData.duration);
+    
+    if (error) {
+      return { isValid: false, error, endTime: null, relativeTime: null };
+    }
+
+    const duration = parseInt(streamData.durationValue);
+    const endTime = calculateEndTime(null, duration, streamData.duration as DurationUnit);
+    const relativeTime = getRelativeTime(endTime);
+
+    return { isValid: true, error: null, endTime, relativeTime };
+  }, [streamData.durationValue, streamData.duration]);
+
+  const isFormValid =
+    !isSubmitting &&
+    streamData.name &&
+    streamData.durationValue &&
+    streamData.recipient &&
+    streamData.amount &&
+    endTimeValidation.isValid;
 
   return (
     <div className="w-full h-full flex flex-col">
@@ -118,7 +153,9 @@ export function PaymentStreamForm({
             </h3>
             <div className="w-full grid grid-cols-[0.5fr_1.5fr] items-end gap-x-6">
               <Input
-                className="border-zinc-700 bg-zinc-800 rounded h-12 placeholder:text-zinc-500 text-white"
+                className={`border-zinc-700 bg-zinc-800 rounded h-12 placeholder:text-zinc-500 text-white ${
+                  endTimeValidation.error ? "border-red-500" : ""
+                }`}
                 maxLength={streamData.duration === "hour" ? 1 : 3}
                 placeholder="Value eg. 1"
                 value={streamData.durationValue}
@@ -133,18 +170,38 @@ export function PaymentStreamForm({
                 placeholder={streamData.duration || "Pick a duration"}
               />
             </div>
+
+            {/* End Time Validation Error */}
+            {endTimeValidation.error && (
+              <div className="mt-2 flex items-start gap-2 text-red-400 text-sm">
+                <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+                <span>{endTimeValidation.error}</span>
+              </div>
+            )}
+
+            {/* End Time Preview */}
+            {endTimeValidation.isValid && endTimeValidation.endTime && (
+              <div className="mt-3 p-3 rounded-lg bg-zinc-800/50 border border-zinc-700">
+                <div className="flex items-start gap-2 text-zinc-300 text-sm">
+                  <Calendar className="w-4 h-4 mt-0.5 flex-shrink-0 text-purple-400" />
+                  <div>
+                    <p className="font-medium text-zinc-200 mb-1">Stream will end:</p>
+                    <p className="text-zinc-400 text-xs">
+                      {formatEndTime(endTimeValidation.endTime)}
+                    </p>
+                    <p className="text-purple-400 text-xs mt-1">
+                      {endTimeValidation.relativeTime}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
 
           <Button
             size="lg"
-            className="justify-self-end self-end h-12 w-fit bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700"
-            disabled={
-              isSubmitting ||
-              !streamData.name ||
-              !streamData.durationValue ||
-              !streamData.recipient ||
-              !streamData.amount
-            }
+            className="justify-self-end self-end h-12 w-fit bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={!isFormValid}
             onClick={onSubmit}
           >
             {isSubmitting ? (

--- a/apps/web/src/lib/stream-validation.ts
+++ b/apps/web/src/lib/stream-validation.ts
@@ -1,0 +1,143 @@
+/**
+ * Stream validation utilities for payment stream forms
+ */
+
+/**
+ * Duration unit multipliers in seconds
+ */
+const DURATION_MULTIPLIERS = {
+  hour: 60 * 60,
+  day: 24 * 60 * 60,
+  week: 7 * 24 * 60 * 60,
+  month: 30 * 24 * 60 * 60,
+  year: 365 * 24 * 60 * 60,
+} as const;
+
+export type DurationUnit = keyof typeof DURATION_MULTIPLIERS;
+
+/**
+ * Convert duration value and unit to seconds
+ */
+export function durationToSeconds(value: number, unit: DurationUnit): number {
+  return value * DURATION_MULTIPLIERS[unit];
+}
+
+/**
+ * Calculate stream end timestamp
+ * @param startTime - Start timestamp in seconds (defaults to now)
+ * @param durationValue - Duration value
+ * @param durationUnit - Duration unit
+ * @returns End timestamp in seconds
+ */
+export function calculateEndTime(
+  startTime: number | null,
+  durationValue: number,
+  durationUnit: DurationUnit
+): number {
+  const start = startTime || Math.floor(Date.now() / 1000);
+  const durationSeconds = durationToSeconds(durationValue, durationUnit);
+  return start + durationSeconds;
+}
+
+/**
+ * Validate that the stream end time is in the future
+ * @param startTime - Start timestamp in seconds (defaults to now)
+ * @param durationValue - Duration value
+ * @param durationUnit - Duration unit
+ * @returns Error message if invalid, null if valid
+ */
+export function validateEndTime(
+  startTime: number | null,
+  durationValue: string,
+  durationUnit: string
+): string | null {
+  // Parse duration value
+  const duration = parseInt(durationValue);
+  
+  if (isNaN(duration)) {
+    return "Duration must be a valid number";
+  }
+  
+  if (duration <= 0) {
+    return "Duration must be greater than zero";
+  }
+  
+  // Validate duration unit
+  if (!isDurationUnit(durationUnit)) {
+    return "Invalid duration unit";
+  }
+  
+  // Calculate end time
+  const endTime = calculateEndTime(startTime, duration, durationUnit);
+  const now = Math.floor(Date.now() / 1000);
+  
+  // Check if end time is in the past
+  if (endTime <= now) {
+    return "Stream end time must be in the future";
+  }
+  
+  // Warn if duration is very short (less than 1 minute)
+  const durationSeconds = durationToSeconds(duration, durationUnit);
+  if (durationSeconds < 60) {
+    return "Duration is too short (minimum 1 minute recommended)";
+  }
+  
+  return null;
+}
+
+/**
+ * Type guard for duration units
+ */
+function isDurationUnit(unit: string): unit is DurationUnit {
+  return unit in DURATION_MULTIPLIERS;
+}
+
+/**
+ * Format timestamp to human-readable date string (UTC)
+ * @param timestamp - Unix timestamp in seconds
+ * @returns Formatted date string
+ */
+export function formatEndTime(timestamp: number): string {
+  const date = new Date(timestamp * 1000);
+  
+  return date.toLocaleString('en-US', {
+    timeZone: 'UTC',
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    timeZoneName: 'short',
+  });
+}
+
+/**
+ * Get relative time description
+ * @param timestamp - Unix timestamp in seconds
+ * @returns Human-readable relative time
+ */
+export function getRelativeTime(timestamp: number): string {
+  const now = Math.floor(Date.now() / 1000);
+  const diff = timestamp - now;
+  
+  if (diff < 0) {
+    return "in the past";
+  }
+  
+  const minutes = Math.floor(diff / 60);
+  const hours = Math.floor(diff / 3600);
+  const days = Math.floor(diff / 86400);
+  const weeks = Math.floor(diff / 604800);
+  const months = Math.floor(diff / 2592000);
+  const years = Math.floor(diff / 31536000);
+  
+  if (years > 0) return `in ${years} year${years !== 1 ? 's' : ''}`;
+  if (months > 0) return `in ${months} month${months !== 1 ? 's' : ''}`;
+  if (weeks > 0) return `in ${weeks} week${weeks !== 1 ? 's' : ''}`;
+  if (days > 0) return `in ${days} day${days !== 1 ? 's' : ''}`;
+  if (hours > 0) return `in ${hours} hour${hours !== 1 ? 's' : ''}`;
+  if (minutes > 0) return `in ${minutes} minute${minutes !== 1 ? 's' : ''}`;
+  
+  return "in less than a minute";
+}


### PR DESCRIPTION
Prevents users from submitting payment streams with end times in the past, saving gas fees on transactions that would fail on-chain.

Changes:

Core Validation Module (stream-validation.ts):
- Add duration-to-seconds conversion for all units (hour, day, week, month, year)
- Implement calculateEndTime() to compute stream end timestamp
- Add validateEndTime() with comprehensive checks:
  * Duration must be a positive number
  * End time must be in the future
  * Minimum duration of 1 minute recommended
  * Timezone-aware using UTC timestamps
- Add formatEndTime() for human-readable date display
- Add getRelativeTime() for user-friendly time descriptions

PaymentStreamForm Updates:
- Add real-time end-time validation using useMemo
- Display inline error messages for invalid durations
- Show computed end date/time preview when valid
- Display relative time ("in 2 days", "in 3 hours", etc.)
- Visual feedback with error styling on duration input
- Disable submit button when end time is invalid
- Add Calendar and AlertCircle icons for better UX

CreatePaymentStream Updates:
- Add end-time validation check before showing confirmation modal
- Show toast error if end time validation fails
- Prevent submission of streams with past end times

Validation Rules:
✓ Duration must be > 0
✓ End time must be in the future
✓ Minimum 1 minute duration recommended
✓ Validates on both input change and submit
✓ Uses UTC for consistent timezone handling

User Experience:
- Clear inline error messages below duration input
- Preview of exact end date/time in UTC
- Relative time display ("in 5 days")
- Submit button disabled for invalid durations
- No wasted gas on invalid transactions

Edge Cases Handled:
- Zero duration → Error: "Duration must be greater than zero"
- Negative duration → Error: "Duration must be greater than zero"
- Past end time → Error: "Stream end time must be in the future"
- Very short duration (< 1 min) → Warning message
- Invalid duration unit → Error: "Invalid duration unit"

Closes #49