### PR TITLE
fix(web): harden optimistic rollbacks and abort pending requests

### DIFF
--- a/apps/web/src/app/(overview)/history/page.tsx
+++ b/apps/web/src/app/(overview)/history/page.tsx
@@ -12,6 +12,7 @@ import { HistoryRecord } from "@/services/types";
 import AppSelect from "@/components/molecules/AppSelect";
 import { createTestnetService } from "@/services";
 import { DISTRIBUTOR_CONTRACT_ID, PAYMENT_STREAM_CONTRACT_ID } from "@/lib/constants";
+import { withAbortSignal } from "@/utils/retry";
 
 const HistoryPage = () => {
     const { address } = useWallet();
@@ -26,7 +27,10 @@ const HistoryPage = () => {
 
     const { data: history, isLoading } = useQuery<HistoryRecord[]>({
         queryKey: ["transaction-history", address],
-        queryFn: () => service.getTransactionHistory(address!),
+        queryFn: ({ signal }) =>
+            address
+                ? withAbortSignal(service.getTransactionHistory(address), signal)
+                : Promise.resolve([]),
         enabled: !!address,
     });
 

--- a/apps/web/src/components/modules/dashboard/StatsOverview.tsx
+++ b/apps/web/src/components/modules/dashboard/StatsOverview.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { createTestnetService } from "@/services";
 import { DISTRIBUTOR_CONTRACT_ID, PAYMENT_STREAM_CONTRACT_ID } from "@/lib/constants";
 import { useMemo } from "react";
+import { withAbortSignal } from "@/utils/retry";
 
 const StatsOverview = () => {
     const { address } = useWallet();
@@ -17,7 +18,10 @@ const StatsOverview = () => {
 
     const { data: streams, isLoading: isLoadingStreams } = useQuery({
         queryKey: ["payment-streams-stats", address],
-        queryFn: () => service.getStreams(address!),
+        queryFn: ({ signal }) =>
+            address
+                ? withAbortSignal(service.getStreams(address), signal)
+                : Promise.resolve([]),
         enabled: !!address,
     });
 

--- a/apps/web/src/components/modules/payment-stream/StreamsHistory.tsx
+++ b/apps/web/src/components/modules/payment-stream/StreamsHistory.tsx
@@ -15,6 +15,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { streamColumns } from "./streamColumns";
 import StreamActionsCell from "./StreamActionsCell";
 import type { StreamRecord } from "@/lib/validations";
+import { withAbortSignal } from "@/utils/retry";
 
 // Mock API function - replace with real API call when backend is ready
 async function fetchStreams(
@@ -127,13 +128,16 @@ export const StreamsHistory = () => {
 
     const { data: streamsData, isPending } = useQuery({
         queryKey: ["payment-streams-table", statusFilter, page, limit, activeTab, address],
-        queryFn: () =>
-            fetchStreams(address ?? "", {
-                page,
-                limit,
-                type: activeTab,
-                status: statusFilter !== "all" ? statusFilter : undefined,
-            }),
+        queryFn: ({ signal }) =>
+            withAbortSignal(
+                fetchStreams(address ?? "", {
+                    page,
+                    limit,
+                    type: activeTab,
+                    status: statusFilter !== "all" ? statusFilter : undefined,
+                }),
+                signal
+            ),
         enabled: !!address && isConnected,
     });
 

--- a/apps/web/src/components/modules/payment-stream/WithdrawStreamModal.tsx
+++ b/apps/web/src/components/modules/payment-stream/WithdrawStreamModal.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dialog"
 import { withdrawStreamSchema, type WithdrawStreamFormData, type StreamRecord } from "@/lib/validations"
 import { StellarService } from "@/lib/stellar"
+import { isAbortError } from "@/utils/retry"
 
 interface WithdrawStreamModalProps {
   open: boolean
@@ -59,25 +60,25 @@ export function WithdrawStreamModal({
   useEffect(() => {
     if (!open || !stream.id) return
 
-    let cancelled = false
+    const controller = new AbortController()
     setIsLoadingAmount(true)
 
-    StellarService.getWithdrawableAmount(stream.id)
+    StellarService.getWithdrawableAmount(stream.id, controller.signal)
       .then(amount => {
-        if (cancelled) return
+        if (controller.signal.aborted) return
         setWithdrawableAmount(amount)
       })
       .catch(error => {
-        if (cancelled) return
+        if (isAbortError(error)) return
         console.error("Failed to fetch withdrawable amount:", error)
         onError?.("Failed to fetch withdrawable amount")
       })
       .finally(() => {
-        if (!cancelled) setIsLoadingAmount(false)
+        if (!controller.signal.aborted) setIsLoadingAmount(false)
       })
 
     return () => {
-      cancelled = true
+      controller.abort()
     }
   }, [open, stream.id, onError])
 

--- a/apps/web/src/components/token-balance/TokenBalanceList.tsx
+++ b/apps/web/src/components/token-balance/TokenBalanceList.tsx
@@ -18,6 +18,7 @@ import {
 import { WalletNetwork } from "@creit.tech/stellar-wallets-kit";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Wallet } from "lucide-react";
+import { isAbortError } from "@/utils/retry";
 
 /**
  * TokenBalanceList Component
@@ -97,9 +98,7 @@ export function TokenBalanceList({ className = "" }: TokenBalanceListProps) {
       return;
     }
 
-    // Cancellation flag - set to true when effect cleanup runs
-    // This prevents race conditions where stale responses overwrite newer state
-    let cancelled = false;
+    const controller = new AbortController();
 
     // Fetch balances
     const fetchBalances = async () => {
@@ -130,7 +129,11 @@ export function TokenBalanceList({ className = "" }: TokenBalanceListProps) {
         });
 
         // Fetch account data from Horizon API
-        const accountInfo = await stellarService.getAccount(address);
+        const accountInfo = await stellarService.getAccount(
+          address,
+          controller.signal
+        );
+        if (controller.signal.aborted) return;
 
         // Transform Horizon response to TokenBalanceData format
         const extractedBalances = extractBalances(accountInfo);
@@ -138,11 +141,12 @@ export function TokenBalanceList({ className = "" }: TokenBalanceListProps) {
         // Sort balances with XLM first, then alphabetically
         const sortedBalances = sortTokenBalances(extractedBalances);
 
-        // Only update state if this request hasn't been cancelled (Requirement 2.3)
-        if (!cancelled) {
-          setBalances(sortedBalances);
-        }
+        setBalances(sortedBalances);
       } catch (err) {
+        if (isAbortError(err)) {
+          return;
+        }
+
         // Log detailed error information for debugging (Requirement 9.4)
         console.error("Failed to fetch token balances:", {
           address,
@@ -159,13 +163,11 @@ export function TokenBalanceList({ className = "" }: TokenBalanceListProps) {
             ? err
             : new Error(String(err || "Unknown error"));
 
-        // Only update error state if this request hasn't been cancelled (Requirement 2.3)
-        if (!cancelled) {
+        if (!controller.signal.aborted) {
           setError(error);
         }
       } finally {
-        // Only update loading state if this request hasn't been cancelled (Requirement 2.3)
-        if (!cancelled) {
+        if (!controller.signal.aborted) {
           setLoading(false);
         }
       }
@@ -173,10 +175,8 @@ export function TokenBalanceList({ className = "" }: TokenBalanceListProps) {
 
     fetchBalances();
 
-    // Cleanup function - mark this request as cancelled (Requirement 2.5)
-    // This runs when dependencies change or component unmounts
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [address, isConnected, network]);
 

--- a/apps/web/src/hooks/use-create-stream.ts
+++ b/apps/web/src/hooks/use-create-stream.ts
@@ -1,27 +1,59 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { QueryClient, QueryKey, useMutation, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
 import { createStream } from '@/lib/api';
+
+interface CreateStreamMutationContext {
+    previousStreams: Array<[QueryKey, unknown]>;
+}
+
+function restorePreviousStreams(
+    queryClient: QueryClient,
+    previousStreams: Array<[QueryKey, unknown]> | undefined
+): boolean {
+    if (!previousStreams?.length) {
+        return false;
+    }
+
+    previousStreams.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+    });
+
+    return true;
+}
 
 export function useCreateStream() {
     const queryClient = useQueryClient();
 
     return useMutation({
         mutationFn: createStream,
-        onMutate: async (newStream) => {
-            await queryClient.cancelQueries({ queryKey: ['streams'] });
-            const previousStreams = queryClient.getQueryData(['streams']);
-
-            // Optimistically update
-            queryClient.setQueryData(['streams'], (old: any[]) => {
-                return old ? [...old, { ...newStream, id: -1, status: 'Active' }] : [];
+        onMutate: async (newStream): Promise<CreateStreamMutationContext> => {
+            const previousStreams = queryClient.getQueriesData({
+                queryKey: ['streams'],
             });
+
+            try {
+                await queryClient.cancelQueries({ queryKey: ['streams'] });
+
+                queryClient.setQueriesData({ queryKey: ['streams'] }, (old: unknown) => {
+                    if (!Array.isArray(old)) {
+                        return old;
+                    }
+                    return [...old, { ...newStream, id: -1, status: 'Active' }];
+                });
+            } catch (error) {
+                console.error('Failed to apply optimistic stream update:', error);
+            }
 
             return { previousStreams };
         },
-        onError: (err, newStream, context) => {
-            queryClient.setQueryData(['streams'], context?.previousStreams);
+        onError: (_error, _newStream, context) => {
+            const restored = restorePreviousStreams(queryClient, context?.previousStreams);
+            if (!restored) {
+                queryClient.invalidateQueries({ queryKey: ['streams'] });
+            }
+            toast.error('Failed to create stream. Refreshing latest data.');
         },
-        onSuccess: (newStreamId, variables) => {
-            // Invalidate queries to refresh data
+        onSettled: () => {
             queryClient.invalidateQueries({ queryKey: ['streams'] });
         },
     });

--- a/apps/web/src/hooks/use-distribute.ts
+++ b/apps/web/src/hooks/use-distribute.ts
@@ -1,13 +1,52 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { QueryClient, QueryKey, useMutation, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
 import { distribute } from '@/lib/api';
+
+interface DistributeMutationContext {
+    previousStreams: Array<[QueryKey, unknown]>;
+}
+
+function restorePreviousStreams(
+    queryClient: QueryClient,
+    previousStreams: Array<[QueryKey, unknown]> | undefined
+): boolean {
+    if (!previousStreams?.length) {
+        return false;
+    }
+
+    previousStreams.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+    });
+
+    return true;
+}
 
 export function useDistribute() {
     const queryClient = useQueryClient();
 
     return useMutation({
         mutationFn: distribute,
-        onSuccess: () => {
-            // Invalidate relevant queries (e.g., balances if we had them)
+        onMutate: async (): Promise<DistributeMutationContext> => {
+            const previousStreams = queryClient.getQueriesData({
+                queryKey: ['streams'],
+            });
+
+            try {
+                await queryClient.cancelQueries({ queryKey: ['streams'] });
+            } catch (error) {
+                console.error('Failed to prepare distribution mutation cache snapshot:', error);
+            }
+
+            return { previousStreams };
+        },
+        onError: (_error, _variables, context) => {
+            const restored = restorePreviousStreams(queryClient, context?.previousStreams);
+            if (!restored) {
+                queryClient.invalidateQueries({ queryKey: ['streams'] });
+            }
+            toast.error('Distribution failed. Refreshing latest data.');
+        },
+        onSettled: () => {
             queryClient.invalidateQueries({ queryKey: ['streams'] });
         },
     });

--- a/apps/web/src/hooks/use-stream-details.ts
+++ b/apps/web/src/hooks/use-stream-details.ts
@@ -4,7 +4,7 @@ import { fetchStream } from '@/lib/api';
 export function useStreamDetails(streamId: number | undefined) {
     return useQuery({
         queryKey: ['stream', streamId],
-        queryFn: () => (streamId ? fetchStream(streamId) : Promise.resolve(null)),
+        queryFn: ({ signal }) => (streamId ? fetchStream(streamId, signal) : Promise.resolve(null)),
         enabled: !!streamId,
     });
 }

--- a/apps/web/src/hooks/use-streams.ts
+++ b/apps/web/src/hooks/use-streams.ts
@@ -1,11 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchUserStreams } from '@/lib/api';
-import { Stream } from '@/types';
 
 export function useStreams(address: string | undefined) {
     return useQuery({
         queryKey: ['streams', address],
-        queryFn: () => (address ? fetchUserStreams(address) : Promise.resolve([])),
+        queryFn: ({ signal }) => (address ? fetchUserStreams(address, signal) : Promise.resolve([])),
         enabled: !!address,
         staleTime: 60 * 1000,
     });

--- a/apps/web/src/hooks/use-withdraw.ts
+++ b/apps/web/src/hooks/use-withdraw.ts
@@ -1,14 +1,77 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { QueryClient, QueryKey, useMutation, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
 import { withdraw } from '@/lib/api';
+
+interface WithdrawMutationContext {
+    previousStreams: Array<[QueryKey, unknown]>;
+    streamQueryKey?: QueryKey;
+    previousStream?: unknown;
+}
+
+function restorePreviousStreams(
+    queryClient: QueryClient,
+    previousStreams: Array<[QueryKey, unknown]> | undefined
+): boolean {
+    if (!previousStreams?.length) {
+        return false;
+    }
+
+    previousStreams.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+    });
+
+    return true;
+}
 
 export function useWithdraw() {
     const queryClient = useQueryClient();
 
     return useMutation({
         mutationFn: withdraw,
-        onSuccess: (_, variables) => {
+        onMutate: async (variables): Promise<WithdrawMutationContext> => {
+            const previousStreams = queryClient.getQueriesData({
+                queryKey: ['streams'],
+            });
+            const streamQueryKey: QueryKey | undefined =
+                typeof variables?.streamId === 'number' ? ['stream', variables.streamId] : undefined;
+            const previousStream = streamQueryKey
+                ? queryClient.getQueryData(streamQueryKey)
+                : undefined;
+
+            try {
+                await queryClient.cancelQueries({ queryKey: ['streams'] });
+                if (streamQueryKey) {
+                    await queryClient.cancelQueries({ queryKey: streamQueryKey });
+                }
+            } catch (error) {
+                console.error('Failed to prepare withdraw mutation cache snapshot:', error);
+            }
+
+            return { previousStreams, streamQueryKey, previousStream };
+        },
+        onError: (_error, variables, context) => {
+            const restoredStreams = restorePreviousStreams(queryClient, context?.previousStreams);
+            let restoredStreamDetails = false;
+
+            if (context?.streamQueryKey && typeof context.previousStream !== 'undefined') {
+                queryClient.setQueryData(context.streamQueryKey, context.previousStream);
+                restoredStreamDetails = true;
+            }
+
+            if (!restoredStreams && !restoredStreamDetails) {
+                queryClient.invalidateQueries({ queryKey: ['streams'] });
+                if (typeof variables?.streamId === 'number') {
+                    queryClient.invalidateQueries({ queryKey: ['stream', variables.streamId] });
+                }
+            }
+
+            toast.error('Withdraw failed. Refreshing latest data.');
+        },
+        onSettled: (_data, _error, variables) => {
             queryClient.invalidateQueries({ queryKey: ['streams'] });
-            queryClient.invalidateQueries({ queryKey: ['stream', variables.streamId] });
+            if (typeof variables?.streamId === 'number') {
+                queryClient.invalidateQueries({ queryKey: ['stream', variables.streamId] });
+            }
         },
     });
 }

--- a/apps/web/src/hooks/useOfframpBridge.ts
+++ b/apps/web/src/hooks/useOfframpBridge.ts
@@ -10,6 +10,7 @@ import {
     getMockDelay,
     isOfframpMockEnabled,
 } from "@/services/offramp.mock";
+import { isAbortError } from "@/utils/retry";
 import type {
     OfframpStep,
     OfframpFormState,
@@ -134,13 +135,22 @@ export function useOfframpBridge(): UseOfframpBridgeReturn {
     // ---------- Effects: Bank Loading ----------
 
     useEffect(() => {
+        const controller = new AbortController();
+
         const fetchBanks = async () => {
             setIsLoadingBanks(true);
             setBanks([]);
             setFormState(prev => ({ ...prev, bankCode: "", accountNumber: "", accountName: "" }));
 
             try {
-                const result = await offrampService.getBankList(formState.country, address || undefined);
+                const result = await offrampService.getBankList(
+                    formState.country,
+                    address || undefined,
+                    controller.signal
+                );
+                if (controller.signal.aborted) {
+                    return;
+                }
                 if (result.success && result.data) {
                     // Deduplicate banks
                     const uniqueBanks = result.data.filter(
@@ -150,13 +160,19 @@ export function useOfframpBridge(): UseOfframpBridgeReturn {
                     setBanks(uniqueBanks);
                 }
             } catch (error) {
+                if (isAbortError(error)) {
+                    return;
+                }
                 console.error("Failed to load banks:", error);
             } finally {
-                setIsLoadingBanks(false);
+                if (!controller.signal.aborted) {
+                    setIsLoadingBanks(false);
+                }
             }
         };
 
         fetchBanks();
+        return () => controller.abort();
     }, [formState.country, address]);
 
     // ---------- Effects: Account Verification ----------
@@ -167,6 +183,7 @@ export function useOfframpBridge(): UseOfframpBridgeReturn {
             return;
         }
 
+        const controller = new AbortController();
         const timer = setTimeout(async () => {
             setIsVerifyingAccount(true);
             try {
@@ -174,22 +191,34 @@ export function useOfframpBridge(): UseOfframpBridgeReturn {
                     formState.bankCode,
                     formState.accountNumber,
                     formState.country,
-                    address || undefined
+                    address || undefined,
+                    controller.signal
                 );
+                if (controller.signal.aborted) {
+                    return;
+                }
 
                 if (result.success && result.data) {
                     setFormState(prev => ({ ...prev, accountName: result.data!.accountName }));
                 } else {
                     setFormState(prev => ({ ...prev, accountName: "" }));
                 }
-            } catch {
+            } catch (error) {
+                if (isAbortError(error)) {
+                    return;
+                }
                 setFormState(prev => ({ ...prev, accountName: "" }));
             } finally {
-                setIsVerifyingAccount(false);
+                if (!controller.signal.aborted) {
+                    setIsVerifyingAccount(false);
+                }
             }
         }, 500);
 
-        return () => clearTimeout(timer);
+        return () => {
+            clearTimeout(timer);
+            controller.abort();
+        };
     }, [formState.bankCode, formState.accountNumber, formState.country, address]);
 
     // ---------- Effects: Real-time Quote ----------
@@ -202,6 +231,7 @@ export function useOfframpBridge(): UseOfframpBridgeReturn {
             return;
         }
 
+        const controller = new AbortController();
         const fetchQuote = async () => {
             setIsLoadingQuote(true);
             try {
@@ -210,7 +240,10 @@ export function useOfframpBridge(): UseOfframpBridgeReturn {
                     amount: amount,
                     country: formState.country,
                     currency: formState.country === "NG" ? "NGN" : formState.country === "GH" ? "GHS" : "KES",
-                });
+                }, controller.signal);
+                if (controller.signal.aborted) {
+                    return;
+                }
 
                 if (result.success && result.data?.best) {
                     setQuote(result.data.best);
@@ -220,15 +253,23 @@ export function useOfframpBridge(): UseOfframpBridgeReturn {
                     setQuoteError(result.error || "No rates available");
                 }
             } catch (error) {
+                if (isAbortError(error)) {
+                    return;
+                }
                 setQuote(null);
                 setQuoteError("Failed to fetch rates");
             } finally {
-                setIsLoadingQuote(false);
+                if (!controller.signal.aborted) {
+                    setIsLoadingQuote(false);
+                }
             }
         };
 
         const timer = setTimeout(fetchQuote, 500);
-        return () => clearTimeout(timer);
+        return () => {
+            clearTimeout(timer);
+            controller.abort();
+        };
     }, [formState.amount, formState.token, formState.country]);
 
     // ---------- Payout Logic ----------

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,8 +1,9 @@
-import { server } from './stellar';
-import { PAYMENT_STREAM_CONTRACT_ID } from './constants';
 import { Stream, StreamStatus } from '../types';
+import { throwIfAborted } from '@/utils/retry';
 
-export async function fetchStream(streamId: number): Promise<Stream | null> {
+export async function fetchStream(streamId: number, signal?: AbortSignal): Promise<Stream | null> {
+    throwIfAborted(signal);
+
     // Construct the simulation transaction to call get_stream(streamId)
     // This is pseudo-code for the exact XDR building using stellar-sdk
     // In a real app we'd use 'soroban-client' or generated bindings.
@@ -16,7 +17,7 @@ export async function fetchStream(streamId: number): Promise<Stream | null> {
     // const res = await server.simulateTransaction(tx);
 
     // Returning mock data for demonstration
-    return {
+    const stream = {
         id: streamId,
         sender: 'G...',
         recipient: 'G...',
@@ -27,16 +28,22 @@ export async function fetchStream(streamId: number): Promise<Stream | null> {
         end_time: Date.now() + 100000,
         status: StreamStatus.Active,
     };
+
+    throwIfAborted(signal);
+    return stream;
 }
 
-export async function fetchUserStreams(address: string): Promise<Stream[]> {
+export async function fetchUserStreams(address: string, signal?: AbortSignal): Promise<Stream[]> {
+    throwIfAborted(signal);
+
     // In a real implementation without an indexer, we would iterate known stream IDs
     // or query a backend.
 
     const streams: Stream[] = [];
     // Mock fetching 5 streams
     for (let i = 1; i <= 5; i++) {
-        const stream = await fetchStream(i);
+        throwIfAborted(signal);
+        const stream = await fetchStream(i, signal);
         if (stream && (stream.sender === address || stream.recipient === address)) {
             streams.push(stream);
         }
@@ -44,6 +51,7 @@ export async function fetchUserStreams(address: string): Promise<Stream[]> {
         if (stream) streams.push(stream);
     }
 
+    throwIfAborted(signal);
     return streams;
 }
 

--- a/apps/web/src/lib/stellar.ts
+++ b/apps/web/src/lib/stellar.ts
@@ -5,6 +5,37 @@ import { PaymentStreamFormData, SUPPORTED_TOKENS, StreamRecord, WithdrawStreamFo
 export const server = new Horizon.Server('https://horizon-testnet.stellar.org')
 export const networkPassphrase = Networks.TESTNET
 
+function createAbortError(): Error {
+  const error = new Error('The operation was aborted')
+  error.name = 'AbortError'
+  return error
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw createAbortError()
+  }
+}
+
+function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  throwIfAborted(signal)
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+
+    const onAbort = () => {
+      clearTimeout(timeout)
+      signal?.removeEventListener('abort', onAbort)
+      reject(createAbortError())
+    }
+
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
 export interface CreateStreamParams {
   senderKeypair: Keypair
   recipientAddress: string
@@ -16,8 +47,10 @@ export interface CreateStreamParams {
 }
 
 export class StellarService {
-  static async createPaymentStream(formData: PaymentStreamFormData): Promise<string> {
+  static async createPaymentStream(formData: PaymentStreamFormData, signal?: AbortSignal): Promise<string> {
     try {
+      throwIfAborted(signal)
+
       // For demo purposes, we'll simulate the transaction
       // In a real implementation, you would:
       // 1. Connect to user's wallet (Freighter, etc.)
@@ -47,10 +80,14 @@ export class StellarService {
       // 3. Submit the transaction to the network
 
       // Simulate network delay
-      await new Promise(resolve => setTimeout(resolve, 2000))
+      await abortableDelay(2000, signal)
+      throwIfAborted(signal)
 
       return streamId
     } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw error
+      }
       console.error('Error creating payment stream:', error)
       throw new Error('Failed to create payment stream: ' + (error instanceof Error ? error.message : 'Unknown error'))
     }
@@ -79,15 +116,17 @@ export class StellarService {
     return num.toFixed(decimals)
   }
 
-  static async getWithdrawableAmount(streamId: string): Promise<string> {
+  static async getWithdrawableAmount(streamId: string, signal?: AbortSignal): Promise<string> {
     try {
+      throwIfAborted(signal)
+
       // In a real implementation, this would call the smart contract
       // For demo purposes, we'll simulate the calculation
 
       console.log('Getting withdrawable amount for stream:', streamId)
 
       // Simulate network delay
-      await new Promise(resolve => setTimeout(resolve, 1000))
+      await abortableDelay(1000, signal)
 
       // Mock calculation - in reality this would be based on:
       // - Current time vs stream start/end time
@@ -95,8 +134,12 @@ export class StellarService {
       // - Already withdrawn amount
       const mockWithdrawableAmount = "150.5000000" // 150.5 tokens available
 
+      throwIfAborted(signal)
       return mockWithdrawableAmount
     } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw error
+      }
       console.error('Error getting withdrawable amount:', error)
       throw new Error('Failed to get withdrawable amount')
     }
@@ -104,13 +147,15 @@ export class StellarService {
 
   static async withdrawFromStream(
     streamId: string,
-    formData: WithdrawStreamFormData
+    formData: WithdrawStreamFormData,
+    signal?: AbortSignal
   ): Promise<string> {
     try {
+      throwIfAborted(signal)
       console.log('Withdrawing from stream:', streamId, formData)
 
       // Validate withdrawal amount against available amount
-      const availableAmount = await this.getWithdrawableAmount(streamId)
+      const availableAmount = await this.getWithdrawableAmount(streamId, signal)
       const requestedAmount = parseFloat(formData.amount)
       const maxAvailable = parseFloat(availableAmount)
 
@@ -124,24 +169,29 @@ export class StellarService {
       // 3. Submit the transaction to the network
 
       // Simulate network delay
-      await new Promise(resolve => setTimeout(resolve, 2000))
+      await abortableDelay(2000, signal)
+      throwIfAborted(signal)
 
       // Mock transaction hash
       const txHash = `withdraw_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`
 
       return txHash
     } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw error
+      }
       console.error('Error withdrawing from stream:', error)
       throw error instanceof Error ? error : new Error('Failed to withdraw from stream')
     }
   }
 
-  static async getStreamDetails(streamId: string): Promise<StreamRecord> {
+  static async getStreamDetails(streamId: string, signal?: AbortSignal): Promise<StreamRecord> {
     try {
+      throwIfAborted(signal)
       console.log('Getting stream details for:', streamId)
 
       // Simulate network delay
-      await new Promise(resolve => setTimeout(resolve, 500))
+      await abortableDelay(500, signal)
 
       // Mock stream data - in reality this would come from the blockchain
       const mockStream: StreamRecord = {
@@ -159,8 +209,12 @@ export class StellarService {
         transferable: false,
       }
 
+      throwIfAborted(signal)
       return mockStream
     } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw error
+      }
       console.error('Error getting stream details:', error)
       throw new Error('Failed to get stream details')
     }

--- a/apps/web/src/services/offramp.mock.ts
+++ b/apps/web/src/services/offramp.mock.ts
@@ -9,6 +9,7 @@ import type {
   VerifyBankAccountResponse,
 } from "@/types/offramp";
 import type { BridgeQuote } from "@/services/allbridge.service";
+import { createAbortError } from "@/utils/retry";
 
 const DEFAULT_DELAYS = {
   sync: 250,
@@ -62,7 +63,26 @@ const shouldFail = (step: string) => {
 export const getMockDelay = (key: DelayKey) =>
   delayOverrides[key] ?? DEFAULT_DELAYS[key];
 
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = (ms: number, signal?: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(createAbortError());
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      reject(createAbortError());
+    };
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 
 const currencyRates: Record<OfframpCountry, number> = {
   NG: 1550,
@@ -162,18 +182,24 @@ export const createMockTxHash = () =>
   `mock-tx-${Math.random().toString(36).slice(2, 12)}`;
 
 export const mockOfframpService = {
-  async syncWallet(): Promise<{ success: boolean; message: string }> {
-    await sleep(getMockDelay("sync"));
+  async syncWallet(
+    _walletId?: string,
+    signal?: AbortSignal,
+  ): Promise<{ success: boolean; message: string }> {
+    await sleep(getMockDelay("sync"), signal);
     return { success: true, message: "Wallet synced (mock)" };
   },
 
-  async getAggregatedRates(params: {
-    token: string;
-    amount: number;
-    country: string;
-    currency: string;
-  }): Promise<AggregatedRatesResponse> {
-    await sleep(getMockDelay("rates"));
+  async getAggregatedRates(
+    params: {
+      token: string;
+      amount: number;
+      country: string;
+      currency: string;
+    },
+    signal?: AbortSignal,
+  ): Promise<AggregatedRatesResponse> {
+    await sleep(getMockDelay("rates"), signal);
     if (shouldFail("rates")) {
       return { success: false, error: "Mock rate provider error" };
     }
@@ -198,8 +224,10 @@ export const mockOfframpService = {
 
   async createOfframp(
     request: Omit<CreateOfframpRequest, "network">,
+    _walletId?: string,
+    signal?: AbortSignal,
   ): Promise<CreateOfframpResponse> {
-    await sleep(getMockDelay("create"));
+    await sleep(getMockDelay("create"), signal);
 
     if (shouldFail("create")) {
       return { success: false, error: "Mock offramp creation failed" };
@@ -235,8 +263,12 @@ export const mockOfframpService = {
     };
   },
 
-  async getBankList(country: OfframpCountry): Promise<BankListResponse> {
-    await sleep(getMockDelay("banks"));
+  async getBankList(
+    country: OfframpCountry,
+    _walletId?: string,
+    signal?: AbortSignal,
+  ): Promise<BankListResponse> {
+    await sleep(getMockDelay("banks"), signal);
     if (shouldFail("banks")) {
       return { success: false, error: "Mock bank list unavailable" };
     }
@@ -247,8 +279,10 @@ export const mockOfframpService = {
     bankCode: string,
     accountNumber: string,
     country: string,
+    _walletId?: string,
+    signal?: AbortSignal,
   ): Promise<VerifyBankAccountResponse> {
-    await sleep(getMockDelay("verify"));
+    await sleep(getMockDelay("verify"), signal);
 
     if (shouldFail("verify")) {
       return { success: false, error: "Mock verification failed" };
@@ -266,22 +300,35 @@ export const mockOfframpService = {
     };
   },
 
-  async saveQuote(): Promise<{ success: boolean; data?: unknown; error?: string }> {
-    await sleep(getMockDelay("saveQuote"));
+  async saveQuote(
+    _params?: unknown,
+    _walletId?: string,
+    signal?: AbortSignal,
+  ): Promise<{ success: boolean; data?: unknown; error?: string }> {
+    await sleep(getMockDelay("saveQuote"), signal);
     return { success: true, data: { saved: true } };
   },
 
-  async updateQuoteTxHash(): Promise<{
+  async updateQuoteTxHash(
+    _transactionReference?: string,
+    _txHash?: string,
+    _walletId?: string,
+    signal?: AbortSignal,
+  ): Promise<{
     success: boolean;
     data?: unknown;
     error?: string;
   }> {
-    await sleep(getMockDelay("updateTx"));
+    await sleep(getMockDelay("updateTx"), signal);
     return { success: true, data: { updated: true } };
   },
 
-  async getQuoteStatus(transactionReference: string): Promise<QuoteStatusResponse> {
-    await sleep(getMockDelay("status"));
+  async getQuoteStatus(
+    transactionReference: string,
+    _walletId?: string,
+    signal?: AbortSignal,
+  ): Promise<QuoteStatusResponse> {
+    await sleep(getMockDelay("status"), signal);
 
     const record = mockQuotes.get(transactionReference);
     if (!record) {

--- a/apps/web/src/services/offramp.service.ts
+++ b/apps/web/src/services/offramp.service.ts
@@ -10,7 +10,7 @@ import type {
     CreateOfframpResponse,
     QuoteStatusResponse,
 } from "@/types/offramp";
-import { withRetry, RetryableError } from "@/utils/retry";
+import { withRetry, RetryableError, isAbortError } from "@/utils/retry";
 import {
     isOfframpMockEnabled,
     mockOfframpService,
@@ -27,21 +27,26 @@ const getHeaders = (walletId?: string) => ({
     ...(walletId ? { "x-wallet-id": walletId } : {}),
 });
 
-async function fetchWithRetry(input: string, init?: RequestInit): Promise<Response> {
+async function fetchWithRetry(input: string, init?: RequestInit, signal?: AbortSignal): Promise<Response> {
+    const requestInit: RequestInit = signal ? { ...init, signal } : { ...init };
+
     return withRetry(async () => {
-        const res = await fetch(input, init);
+        const res = await fetch(input, requestInit);
         if (res.status >= 500) throw new RetryableError(res.statusText, res.status);
         return res;
-    });
+    }, { signal });
 }
 
 const realOfframpService = {
-    async syncWallet(walletId: string): Promise<{ success: boolean; message: string }> {
+    async syncWallet(
+        walletId: string,
+        signal?: AbortSignal
+    ): Promise<{ success: boolean; message: string }> {
         try {
             const res = await fetchWithRetry(`${OFFRAMP_API_BASE}/sync`, {
                 method: "GET",
                 headers: getHeaders(walletId),
-            });
+            }, signal);
 
             const data = await res.json();
             if (!res.ok) {
@@ -51,6 +56,9 @@ const realOfframpService = {
 
             return { success: true, message: data.message || "Wallet synced" };
         } catch (error) {
+            if (isAbortError(error)) {
+                throw error;
+            }
             console.error("Wallet sync failed:", error);
             return {
                 success: false,
@@ -59,12 +67,15 @@ const realOfframpService = {
         }
     },
 
-    async getAggregatedRates(params: {
-        token: string;
-        amount: number;
-        country: string;
-        currency: string;
-    }): Promise<AggregatedRatesResponse> {
+    async getAggregatedRates(
+        params: {
+            token: string;
+            amount: number;
+            country: string;
+            currency: string;
+        },
+        signal?: AbortSignal
+    ): Promise<AggregatedRatesResponse> {
         try {
             const queryParams = new URLSearchParams({
                 token: params.token,
@@ -77,7 +88,7 @@ const realOfframpService = {
             const res = await fetchWithRetry(`${OFFRAMP_API_BASE}/rates?${queryParams}`, {
                 method: "GET",
                 headers: getHeaders(),
-            });
+            }, signal);
 
             const data = await res.json();
 
@@ -90,6 +101,9 @@ const realOfframpService = {
 
             return { success: true, data: data.data || data };
         } catch (error) {
+            if (isAbortError(error)) {
+                throw error;
+            }
             return {
                 success: false,
                 error: error instanceof Error ? error.message : "Failed to get rates",
@@ -99,14 +113,15 @@ const realOfframpService = {
 
     async createOfframp(
         request: Omit<CreateOfframpRequest, "network">,
-        walletId: string
+        walletId: string,
+        signal?: AbortSignal
     ): Promise<CreateOfframpResponse> {
         try {
             const res = await fetchWithRetry(`${OFFRAMP_API_BASE}/create`, {
                 method: "POST",
                 headers: getHeaders(walletId),
                 body: JSON.stringify({ ...request, network: "polygon" }),
-            });
+            }, signal);
 
             const data = await res.json();
 
@@ -117,6 +132,9 @@ const realOfframpService = {
 
             return { success: true, data: data.data || data };
         } catch (error) {
+            if (isAbortError(error)) {
+                throw error;
+            }
             return {
                 success: false,
                 error: error instanceof Error ? error.message : "Failed to create offramp",
@@ -124,12 +142,16 @@ const realOfframpService = {
         }
     },
 
-    async getBankList(country: OfframpCountry, walletId?: string): Promise<BankListResponse> {
+    async getBankList(
+        country: OfframpCountry,
+        walletId?: string,
+        signal?: AbortSignal
+    ): Promise<BankListResponse> {
         try {
             const res = await fetchWithRetry(`${OFFRAMP_API_BASE}/banks?country=${country}`, {
                 method: "GET",
                 headers: getHeaders(walletId),
-            });
+            }, signal);
 
             const data = await res.json();
 
@@ -140,6 +162,9 @@ const realOfframpService = {
 
             return { success: true, data: data.data || data };
         } catch (error) {
+            if (isAbortError(error)) {
+                throw error;
+            }
             return {
                 success: false,
                 error: error instanceof Error ? error.message : "Failed to fetch bank list",
@@ -151,14 +176,15 @@ const realOfframpService = {
         bankCode: string,
         accountNumber: string,
         country: string,
-        walletId?: string
+        walletId?: string,
+        signal?: AbortSignal
     ): Promise<VerifyBankAccountResponse> {
         try {
             const res = await fetchWithRetry(`${OFFRAMP_API_BASE}/verify-account`, {
                 method: "POST",
                 headers: getHeaders(walletId),
                 body: JSON.stringify({ bankCode, accountNumber, country }),
-            });
+            }, signal);
 
             const data = await res.json();
 
@@ -171,6 +197,9 @@ const realOfframpService = {
 
             return { success: true, data: data.data || data };
         } catch (error) {
+            if (isAbortError(error)) {
+                throw error;
+            }
             return {
                 success: false,
                 error: error instanceof Error ? error.message : "Failed to verify bank account",
@@ -195,14 +224,15 @@ const realOfframpService = {
             amountUsd?: number;
             amountLocal?: number;
         },
-        walletId?: string
+        walletId?: string,
+        signal?: AbortSignal
     ): Promise<{ success: boolean; data?: unknown; error?: string }> {
         try {
             const res = await fetchWithRetry(`${OFFRAMP_API_BASE}/quote/save`, {
                 method: "POST",
                 headers: getHeaders(walletId),
                 body: JSON.stringify(params),
-            });
+            }, signal);
 
             const data = await res.json();
 
@@ -212,6 +242,9 @@ const realOfframpService = {
 
             return { success: true, data: data.data || data };
         } catch (error) {
+            if (isAbortError(error)) {
+                throw error;
+            }
             return {
                 success: false,
                 error: error instanceof Error ? error.message : "Failed to save quote",
@@ -222,14 +255,15 @@ const realOfframpService = {
     async updateQuoteTxHash(
         transactionReference: string,
         txHash: string,
-        walletId?: string
+        walletId?: string,
+        signal?: AbortSignal
     ): Promise<{ success: boolean; data?: unknown; error?: string }> {
         try {
             const res = await fetchWithRetry(`${OFFRAMP_API_BASE}/quote/update-tx`, {
                 method: "POST",
                 headers: getHeaders(walletId),
                 body: JSON.stringify({ transactionReference, txHash }),
-            });
+            }, signal);
 
             const data = await res.json();
 
@@ -239,6 +273,9 @@ const realOfframpService = {
 
             return { success: true, data: data.data || data };
         } catch (error) {
+            if (isAbortError(error)) {
+                throw error;
+            }
             return {
                 success: false,
                 error: error instanceof Error ? error.message : "Failed to update tx hash",
@@ -248,7 +285,8 @@ const realOfframpService = {
 
     async getQuoteStatus(
         transactionReference: string,
-        walletId?: string
+        walletId?: string,
+        signal?: AbortSignal
     ): Promise<QuoteStatusResponse> {
         try {
             const res = await fetchWithRetry(
@@ -256,7 +294,8 @@ const realOfframpService = {
                 {
                     method: "GET",
                     headers: getHeaders(walletId),
-                }
+                },
+                signal
             );
 
             const data = await res.json();
@@ -270,6 +309,9 @@ const realOfframpService = {
 
             return { success: true, data: data.data || data };
         } catch (error) {
+            if (isAbortError(error)) {
+                throw error;
+            }
             return {
                 success: false,
                 error: error instanceof Error ? error.message : "Failed to get quote status",

--- a/apps/web/src/services/stellar.service.ts
+++ b/apps/web/src/services/stellar.service.ts
@@ -52,7 +52,7 @@ import {
   ValidationError,
   parseError,
 } from './errors';
-import { withRetry } from '@/utils/retry';
+import { isAbortError, withAbortSignal, withRetry } from '@/utils/retry';
 
 // Default configuration values
 const DEFAULT_TIMEOUT = 30; // seconds
@@ -95,10 +95,10 @@ export class StellarService {
    * @param address - Stellar account address
    * @returns Account information including balances
    */
-  async getAccount(address: string): Promise<AccountInfo> {
+  async getAccount(address: string, signal?: AbortSignal): Promise<AccountInfo> {
     return withRetry(async () => {
       try {
-        const account = await this.horizonServer.loadAccount(address);
+        const account = await withAbortSignal(this.horizonServer.loadAccount(address), signal);
 
         const balances: AccountBalance[] = account.balances.map((bal: any) => ({
           balance: bal.balance,
@@ -113,13 +113,16 @@ export class StellarService {
           balances,
         };
       } catch (error) {
+        if (isAbortError(error)) {
+          throw error;
+        }
         const err = error as Error & { response?: { status?: number } };
         if (err?.response?.status === 404) {
           throw new AccountNotFoundError(address, err); // 404 — not retried
         }
         throw parseError(error);
       }
-    }, { maxRetries: this.maxRetries });
+    }, { maxRetries: this.maxRetries, signal });
   }
 
   /**

--- a/apps/web/src/utils/retry.ts
+++ b/apps/web/src/utils/retry.ts
@@ -2,6 +2,7 @@ export interface RetryOptions {
     maxRetries?: number;
     baseDelay?: number;
     maxDelay?: number;
+    signal?: AbortSignal;
 }
 
 export class RetryableError extends Error {
@@ -14,7 +15,50 @@ export class RetryableError extends Error {
     }
 }
 
+export function createAbortError(message: string = "The operation was aborted"): Error {
+    const error = new Error(message);
+    error.name = "AbortError";
+    return error;
+}
+
+export function isAbortError(error: unknown): boolean {
+    if (error instanceof DOMException) {
+        return error.name === "AbortError";
+    }
+    return error instanceof Error && error.name === "AbortError";
+}
+
+export function throwIfAborted(signal?: AbortSignal): void {
+    if (signal?.aborted) {
+        throw createAbortError();
+    }
+}
+
+export async function withAbortSignal<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+    throwIfAborted(signal);
+    if (!signal) {
+        return promise;
+    }
+
+    return new Promise<T>((resolve, reject) => {
+        const onAbort = () => reject(createAbortError());
+        signal.addEventListener("abort", onAbort, { once: true });
+
+        promise.then(
+            (value) => {
+                signal.removeEventListener("abort", onAbort);
+                resolve(value);
+            },
+            (error) => {
+                signal.removeEventListener("abort", onAbort);
+                reject(error);
+            }
+        );
+    });
+}
+
 export function isRetryable(error: unknown): boolean {
+    if (isAbortError(error)) return false;
     if (error instanceof RetryableError) return true;
     if (error instanceof TypeError) return true; // network error
     if (error instanceof Error) {
@@ -25,24 +69,41 @@ export function isRetryable(error: unknown): boolean {
     return true; // unknown errors are retried
 }
 
-function sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+    throwIfAborted(signal);
+
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            signal?.removeEventListener("abort", onAbort);
+            resolve();
+        }, ms);
+
+        const onAbort = () => {
+            clearTimeout(timer);
+            signal?.removeEventListener("abort", onAbort);
+            reject(createAbortError());
+        };
+
+        signal?.addEventListener("abort", onAbort, { once: true });
+    });
 }
 
 export async function withRetry<T>(
     fn: () => Promise<T>,
-    { maxRetries = 3, baseDelay = 1000, maxDelay = 10_000 }: RetryOptions = {}
+    { maxRetries = 3, baseDelay = 1000, maxDelay = 10_000, signal }: RetryOptions = {}
 ): Promise<T> {
     let lastError: unknown;
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        throwIfAborted(signal);
         try {
             return await fn();
         } catch (error) {
+            if (isAbortError(error)) throw error;
             lastError = error;
             if (!isRetryable(error) || attempt === maxRetries) throw error;
             const delay = Math.min(baseDelay * 2 ** attempt + Math.random() * 1000, maxDelay);
-            await sleep(delay);
+            await sleep(delay, signal);
         }
     }
 


### PR DESCRIPTION
 Closes #43
  Closes #46

  ## Summary
  This PR fixes optimistic update rollback integrity for stream-related mutations and adds proper request cancellation with
  `AbortController` to prevent stale updates and lingering network calls.

  ## What Was Implemented
  - Hardened optimistic mutation lifecycle in:
    - `use-create-stream.ts`
    - `use-distribute.ts`
    - `use-withdraw.ts`
  - Added safe `onMutate` handling (wrapped cache operations to avoid throwing).
  - Added robust `onError` rollback:
    - Restores previous cache snapshot when context exists.
    - Falls back to query invalidation when context is missing.
  - Added `onSettled` invalidation to always re-sync (`['streams']`, plus per-stream key where relevant).
  - Added failure toasts for mutation errors.
  - Replaced cancelled-flag patterns with `AbortController` in:
    - `TokenBalanceList.tsx`
    - `WithdrawStreamModal.tsx`
    - request-driven effects in offramp flow
  - Added abort-aware utilities and signal propagation:
    - `apps/web/src/utils/retry.ts`
    - `apps/web/src/services/offramp.service.ts`
    - `apps/web/src/services/offramp.mock.ts`
    - `apps/web/src/services/stellar.service.ts`
    - queryFns now consume React Query `signal` in stream/history/stats hooks/components.

  ## Implementation Details
  - Introduced abort helpers (`isAbortError`, `throwIfAborted`, `withAbortSignal`) and made retry logic abort-safe.
  - Updated data-fetch layers to accept `AbortSignal` and treat `AbortError` as expected (no user-facing error).
  - Ensured failed optimistic mutations cannot leave phantom cache entries behind after failures.

  ## How to Test
  1. Trigger stream creation failure (e.g., disconnect/reject during tx) and confirm no phantom `id: -1` stream remains.
  2. Trigger failed distribute/withdraw and confirm list rolls back or refetches to real state.
  3. Navigate quickly between pages with active fetches and confirm pending requests are aborted in Network tab.
  4. Confirm aborted requests do not show error toasts/console noise as real errors.
  5. Run:
     - `pnpm lint`
     - `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of cancelled requests throughout the application.
  * Fixed cache recovery when mutations fail or are interrupted.

* **Improvements**
  * Enhanced performance when navigating between pages or closing dialogs by properly cancelling in-flight requests.
  * Better error messaging and recovery for interrupted operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->