### PR TITLE
feat(web): add Playwright E2E tests for critical user journeys

### DIFF
--- a/apps/web/e2e/distribution.spec.ts
+++ b/apps/web/e2e/distribution.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from '@playwright/test';
+import { injectConnectedWallet, clearWalletState, mockRpcCalls } from './helpers/mock-wallet';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+test.describe('Distribution', () => {
+  test.describe('unauthenticated', () => {
+    test.beforeEach(async ({ page }) => {
+      await clearWalletState(page);
+    });
+
+    test('shows connect wallet prompt when not connected', async ({ page }) => {
+      await page.goto('/distribution');
+      await expect(page.getByText(/connect your stellar wallet/i)).toBeVisible();
+    });
+  });
+
+  test.describe('authenticated', () => {
+    test.beforeEach(async ({ page }) => {
+      await injectConnectedWallet(page);
+      await mockRpcCalls(page);
+    });
+
+    test('renders Create Distribution heading', async ({ page }) => {
+      await page.goto('/distribution');
+      await expect(page.getByText('Create Distribution')).toBeVisible();
+    });
+
+    test('renders recipient table with default rows', async ({ page }) => {
+      await page.goto('/distribution');
+      // Default 2 recipient rows are added on mount
+      const rows = page.locator('tbody tr');
+      await expect(rows).toHaveCount(2);
+    });
+
+    test('Add Row button adds a new recipient row', async ({ page }) => {
+      await page.goto('/distribution');
+      await page.getByRole('button', { name: /add row/i }).click();
+      const rows = page.locator('tbody tr');
+      await expect(rows).toHaveCount(3);
+    });
+
+    test('delete button removes a recipient row', async ({ page }) => {
+      await page.goto('/distribution');
+      // Add a third row first so we can delete without going below 2
+      await page.getByRole('button', { name: /add row/i }).click();
+      await expect(page.locator('tbody tr')).toHaveCount(3);
+
+      // Click the first delete button
+      await page.locator('tbody tr').first().getByRole('button').click();
+      await expect(page.locator('tbody tr')).toHaveCount(2);
+    });
+
+    test('can switch between Equal and Weighted distribution types', async ({ page }) => {
+      await page.goto('/distribution');
+
+      // Default is equal
+      await expect(page.getByRole('button', { name: 'Equal' })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Weighted' })).toBeVisible();
+
+      // Switch to weighted
+      await page.getByRole('button', { name: 'Weighted' }).click();
+      // In weighted mode, amount column header changes
+      await expect(page.getByText('Amount').first()).toBeVisible();
+    });
+
+    test('equal mode shows amount per address input', async ({ page }) => {
+      await page.goto('/distribution');
+      await page.getByRole('button', { name: 'Equal' }).click();
+      await expect(page.getByPlaceholder('Amount')).toBeVisible();
+    });
+
+    test('Distribute Token button is disabled with empty recipients', async ({ page }) => {
+      await page.goto('/distribution');
+      // Remove all rows
+      const deleteButtons = page.locator('tbody tr button');
+      const count = await deleteButtons.count();
+      for (let i = 0; i < count; i++) {
+        await page.locator('tbody tr button').first().click();
+      }
+      await expect(page.getByRole('button', { name: /distribute token/i })).toBeDisabled();
+    });
+
+    test('CSV upload area is visible', async ({ page }) => {
+      await page.goto('/distribution');
+      await expect(page.getByText(/drag and drop a csv file/i)).toBeVisible();
+      await expect(page.getByRole('button', { name: /select file/i })).toBeVisible();
+      await expect(page.getByRole('button', { name: /download template/i })).toBeVisible();
+    });
+
+    test('uploading a valid CSV adds recipients', async ({ page }) => {
+      await page.goto('/distribution');
+
+      // Create a temp CSV file
+      const csvContent = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF\nGBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\n';
+      const tmpFile = path.join(os.tmpdir(), 'test-recipients.csv');
+      fs.writeFileSync(tmpFile, csvContent);
+
+      const fileInput = page.locator('input[type="file"]');
+      await fileInput.setInputFiles(tmpFile);
+
+      // Should show success message
+      await expect(page.getByText(/successfully imported/i)).toBeVisible({ timeout: 5000 });
+
+      fs.unlinkSync(tmpFile);
+    });
+
+    test('uploading an invalid CSV shows error', async ({ page }) => {
+      await page.goto('/distribution');
+
+      const csvContent = 'not-a-valid-address\nalso-invalid\n';
+      const tmpFile = path.join(os.tmpdir(), 'bad-recipients.csv');
+      fs.writeFileSync(tmpFile, csvContent);
+
+      const fileInput = page.locator('input[type="file"]');
+      await fileInput.setInputFiles(tmpFile);
+
+      // Should show error state
+      await expect(
+        page.getByText(/error|invalid|failed/i).first()
+      ).toBeVisible({ timeout: 5000 });
+
+      fs.unlinkSync(tmpFile);
+    });
+
+    test('token selector is visible and functional', async ({ page }) => {
+      await page.goto('/distribution');
+      await expect(page.getByRole('combobox').first()).toBeVisible();
+    });
+  });
+});

--- a/apps/web/e2e/helpers/mock-wallet.ts
+++ b/apps/web/e2e/helpers/mock-wallet.ts
@@ -1,0 +1,47 @@
+import { Page } from '@playwright/test';
+
+export const MOCK_ADDRESS = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+
+/**
+ * Injects a connected wallet state into localStorage before the page loads.
+ * This bypasses the real browser extension entirely.
+ */
+export async function injectConnectedWallet(page: Page, address = MOCK_ADDRESS) {
+  await page.addInitScript((addr) => {
+    localStorage.setItem('stellar_wallet_address', addr);
+    localStorage.setItem('stellar_wallet_id', 'freighter');
+    localStorage.setItem('stellar_wallet_network', 'Test SDF Network ; September 2015');
+  }, address);
+}
+
+/**
+ * Clears wallet state so the page loads as disconnected.
+ */
+export async function clearWalletState(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.removeItem('stellar_wallet_address');
+    localStorage.removeItem('stellar_wallet_id');
+    localStorage.removeItem('stellar_wallet_network');
+  });
+}
+
+/**
+ * Mocks all Soroban RPC calls so no real network requests are made.
+ */
+export async function mockRpcCalls(page: Page) {
+  await page.route('**/soroban-testnet.stellar.org/**', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ result: { status: 'SUCCESS', ledger: 1 } }),
+    });
+  });
+
+  await page.route('**/horizon-testnet.stellar.org/**', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ _embedded: { records: [] } }),
+    });
+  });
+}

--- a/apps/web/e2e/history.spec.ts
+++ b/apps/web/e2e/history.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+import { injectConnectedWallet, clearWalletState, mockRpcCalls } from './helpers/mock-wallet';
+
+test.describe('History Page', () => {
+  test.describe('unauthenticated', () => {
+    test.beforeEach(async ({ page }) => {
+      await clearWalletState(page);
+    });
+
+    test('shows connect wallet prompt when not connected', async ({ page }) => {
+      await page.goto('/history');
+      await expect(page.getByText(/connect your wallet/i)).toBeVisible();
+      await expect(page.getByRole('button', { name: /connect wallet/i })).toBeVisible();
+    });
+  });
+
+  test.describe('authenticated', () => {
+    test.beforeEach(async ({ page }) => {
+      await injectConnectedWallet(page);
+      await mockRpcCalls(page);
+    });
+
+    test('renders Transaction History title', async ({ page }) => {
+      await page.goto('/history');
+      await expect(page.getByText('Transaction History')).toBeVisible();
+    });
+
+    test('renders filter controls', async ({ page }) => {
+      await page.goto('/history');
+      await expect(page.getByText('Type')).toBeVisible();
+      await expect(page.getByText('Token')).toBeVisible();
+      await expect(page.getByText('Status')).toBeVisible();
+      await expect(page.getByText('From')).toBeVisible();
+      await expect(page.getByText('To')).toBeVisible();
+    });
+
+    test('type filter has correct options', async ({ page }) => {
+      await page.goto('/history');
+      // Open the Type filter dropdown
+      await page.locator('[placeholder="Type"]').click();
+      await expect(page.getByRole('option', { name: 'All Types' })).toBeVisible();
+      await expect(page.getByRole('option', { name: 'Streams' })).toBeVisible();
+      await expect(page.getByRole('option', { name: 'Distributions' })).toBeVisible();
+    });
+
+    test('status filter has correct options', async ({ page }) => {
+      await page.goto('/history');
+      await page.locator('[placeholder="Status"]').click();
+      await expect(page.getByRole('option', { name: 'All Statuses' })).toBeVisible();
+      await expect(page.getByRole('option', { name: 'Completed' })).toBeVisible();
+      await expect(page.getByRole('option', { name: 'Active' })).toBeVisible();
+    });
+
+    test('date range inputs accept values', async ({ page }) => {
+      await page.goto('/history');
+      await page.locator('input[type="date"]').first().fill('2025-01-01');
+      await page.locator('input[type="date"]').last().fill('2025-12-31');
+      // Verify values were set
+      await expect(page.locator('input[type="date"]').first()).toHaveValue('2025-01-01');
+      await expect(page.locator('input[type="date"]').last()).toHaveValue('2025-12-31');
+    });
+
+    test('Reset button appears when filters are active', async ({ page }) => {
+      await page.goto('/history');
+      // Apply a filter
+      await page.locator('[placeholder="Type"]').click();
+      await page.getByRole('option', { name: 'Streams' }).click();
+      await expect(page.getByRole('button', { name: /reset/i })).toBeVisible();
+    });
+
+    test('Reset button clears all filters', async ({ page }) => {
+      await page.goto('/history');
+      // Apply filters
+      await page.locator('[placeholder="Type"]').click();
+      await page.getByRole('option', { name: 'Streams' }).click();
+      await page.locator('input[type="date"]').first().fill('2025-01-01');
+
+      // Reset
+      await page.getByRole('button', { name: /reset/i }).click();
+
+      // Filters should be cleared from URL
+      await expect(page).not.toHaveURL(/type=Stream/);
+      await expect(page).not.toHaveURL(/from=2025/);
+    });
+
+    test('filters are reflected in the URL', async ({ page }) => {
+      await page.goto('/history');
+      await page.locator('[placeholder="Type"]').click();
+      await page.getByRole('option', { name: 'Streams' }).click();
+      await expect(page).toHaveURL(/type=Stream/);
+    });
+
+    test('empty state renders without crashing when no transactions', async ({ page }) => {
+      await page.goto('/history');
+      // With mocked RPC returning empty, the table should render without errors
+      await page.waitForLoadState('networkidle');
+      // Page should still be visible
+      await expect(page.getByText('Transaction History')).toBeVisible();
+    });
+  });
+});

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import { injectConnectedWallet, mockRpcCalls } from './helpers/mock-wallet';
+
+test.describe('Navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectConnectedWallet(page);
+    await mockRpcCalls(page);
+  });
+
+  test('root redirects to /dashboard', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/dashboard/);
+  });
+
+  test('dashboard page loads without errors', async ({ page }) => {
+    await page.goto('/dashboard');
+    await expect(page.locator('h1, [data-slot="sidebar-title"]').first()).toBeVisible();
+  });
+
+  test('sidebar links navigate to correct pages', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    const navLinks = [
+      { label: 'Distribution', url: '/distribution' },
+      { label: 'History', url: '/history' },
+      { label: 'Payment Stream', url: '/payment-stream' },
+      { label: 'Offramp', url: '/offramp' },
+    ];
+
+    for (const link of navLinks) {
+      await page.goto('/dashboard');
+      // Click the sidebar link by its text
+      await page.getByRole('link', { name: link.label }).first().click();
+      await expect(page).toHaveURL(new RegExp(link.url));
+    }
+  });
+
+  test('all main pages load without JS errors', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+
+    const pages = ['/dashboard', '/distribution', '/history', '/payment-stream', '/offramp'];
+    for (const path of pages) {
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
+    }
+
+    expect(errors).toHaveLength(0);
+  });
+
+  test('not-found page renders for unknown routes', async ({ page }) => {
+    await page.goto('/this-route-does-not-exist');
+    // Next.js 404 page or custom not-found
+    const status = page.url();
+    expect(status).toBeTruthy();
+    // Should not redirect to dashboard
+    expect(page.url()).not.toMatch(/\/dashboard/);
+  });
+});

--- a/apps/web/e2e/offramp.spec.ts
+++ b/apps/web/e2e/offramp.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import { injectConnectedWallet, clearWalletState, mockRpcCalls } from './helpers/mock-wallet';
+
+test.describe('Offramp', () => {
+  test.describe('unauthenticated', () => {
+    test.beforeEach(async ({ page }) => {
+      await clearWalletState(page);
+    });
+
+    test('shows connect wallet prompt when not connected', async ({ page }) => {
+      await page.goto('/offramp');
+      await expect(page.getByText(/connect your stellar wallet/i)).toBeVisible();
+    });
+  });
+
+  test.describe('authenticated', () => {
+    test.beforeEach(async ({ page }) => {
+      await injectConnectedWallet(page);
+      await mockRpcCalls(page);
+
+      // Mock the offramp backend API
+      await page.route('**/api/**', (route) => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ banks: [], quote: null }),
+        });
+      });
+    });
+
+    test('renders Offramp page title', async ({ page }) => {
+      await page.goto('/offramp');
+      await expect(page.getByText('Offramp')).toBeVisible();
+    });
+
+    test('renders the offramp form in initial state', async ({ page }) => {
+      await page.goto('/offramp');
+      // The form step should be visible
+      await expect(page.getByText(/withdraw stellar usdc/i)).toBeVisible();
+    });
+
+    test('shows info banner about supported countries', async ({ page }) => {
+      await page.goto('/offramp');
+      await expect(page.getByText(/nigeria|ghana|kenya/i)).toBeVisible();
+    });
+
+    test('shows info message about Allbridge', async ({ page }) => {
+      await page.goto('/offramp');
+      await expect(page.getByText(/allbridge/i)).toBeVisible();
+    });
+  });
+});

--- a/apps/web/e2e/payment-stream.spec.ts
+++ b/apps/web/e2e/payment-stream.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+import { injectConnectedWallet, clearWalletState, mockRpcCalls } from './helpers/mock-wallet';
+
+const VALID_RECIPIENT = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+test.describe('Payment Stream', () => {
+  test.describe('unauthenticated', () => {
+    test.beforeEach(async ({ page }) => {
+      await clearWalletState(page);
+    });
+
+    test('shows connect wallet prompt when not connected', async ({ page }) => {
+      await page.goto('/payment-stream');
+      await expect(page.getByText(/connect your stellar wallet/i)).toBeVisible();
+      await expect(page.getByRole('button', { name: /connect wallet/i })).toBeVisible();
+    });
+  });
+
+  test.describe('authenticated', () => {
+    test.beforeEach(async ({ page }) => {
+      await injectConnectedWallet(page);
+      await mockRpcCalls(page);
+    });
+
+    test('renders Payment Streams page title', async ({ page }) => {
+      await page.goto('/payment-stream');
+      await expect(page.getByText('Payment Streams')).toBeVisible();
+    });
+
+    test('renders the stream creation form', async ({ page }) => {
+      await page.goto('/payment-stream');
+      await expect(page.getByPlaceholder(/monthly salary/i)).toBeVisible();
+      await expect(page.getByPlaceholder(/enter total amount/i)).toBeVisible();
+      await expect(page.getByPlaceholder(/GXXX/i)).toBeVisible();
+    });
+
+    test('Proceed button is disabled when form is empty', async ({ page }) => {
+      await page.goto('/payment-stream');
+      await expect(page.getByRole('button', { name: /proceed/i })).toBeDisabled();
+    });
+
+    test('filling the form enables the Proceed button', async ({ page }) => {
+      await page.goto('/payment-stream');
+
+      await page.getByPlaceholder(/monthly salary/i).fill('Test Stream');
+      await page.getByPlaceholder(/enter total amount/i).fill('100');
+      await page.getByPlaceholder(/GXXX/i).fill(VALID_RECIPIENT);
+
+      // Fill duration value
+      await page.locator('input[placeholder="Value eg. 1"]').fill('30');
+
+      // Select duration unit via the dropdown
+      await page.locator('button[role="combobox"]').last().click();
+      await page.getByRole('option', { name: /day/i }).first().click();
+
+      await expect(page.getByRole('button', { name: /proceed/i })).toBeEnabled();
+    });
+
+    test('shows end time preview after valid duration is entered', async ({ page }) => {
+      await page.goto('/payment-stream');
+
+      await page.locator('input[placeholder="Value eg. 1"]').fill('7');
+      await page.locator('button[role="combobox"]').last().click();
+      await page.getByRole('option', { name: /day/i }).first().click();
+
+      await expect(page.getByText(/stream will end/i)).toBeVisible();
+    });
+
+    test('shows validation error for invalid duration', async ({ page }) => {
+      await page.goto('/payment-stream');
+
+      // Enter a past/invalid duration value
+      await page.locator('input[placeholder="Value eg. 1"]').fill('0');
+      await page.locator('button[role="combobox"]').last().click();
+      await page.getByRole('option', { name: /day/i }).first().click();
+
+      // Should show an error or keep button disabled
+      await expect(page.getByRole('button', { name: /proceed/i })).toBeDisabled();
+    });
+
+    test('shows beta warning banner on mainnet info message', async ({ page }) => {
+      await page.goto('/payment-stream');
+      // The page has a beta warning info message
+      await expect(page.getByText(/beta/i)).toBeVisible();
+    });
+  });
+});

--- a/apps/web/e2e/tsconfig.json
+++ b/apps/web/e2e/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/apps/web/e2e/wallet-connection.spec.ts
+++ b/apps/web/e2e/wallet-connection.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from '@playwright/test';
+import { clearWalletState, injectConnectedWallet, MOCK_ADDRESS } from './helpers/mock-wallet';
+
+test.describe('Wallet Connection', () => {
+  test.describe('disconnected state', () => {
+    test.beforeEach(async ({ page }) => {
+      await clearWalletState(page);
+    });
+
+    test('shows Connect Wallet button in navbar when disconnected', async ({ page }) => {
+      await page.goto('/dashboard');
+      await expect(page.getByRole('button', { name: /connect wallet/i })).toBeVisible();
+    });
+
+    test('clicking Connect Wallet opens the wallet modal', async ({ page }) => {
+      await page.goto('/dashboard');
+      await page.getByRole('button', { name: /connect wallet/i }).click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+      await expect(page.getByText('Connect Wallet')).toBeVisible();
+    });
+
+    test('wallet modal lists supported wallets', async ({ page }) => {
+      await page.goto('/dashboard');
+      await page.getByRole('button', { name: /connect wallet/i }).click();
+
+      const wallets = ['Freighter', 'Albedo', 'xBull', 'Rabet', 'Lobstr'];
+      for (const wallet of wallets) {
+        await expect(page.getByText(wallet)).toBeVisible();
+      }
+    });
+
+    test('Connect Now button is disabled until a wallet is selected', async ({ page }) => {
+      await page.goto('/dashboard');
+      await page.getByRole('button', { name: /connect wallet/i }).click();
+      await expect(page.getByRole('button', { name: /connect now/i })).toBeDisabled();
+    });
+
+    test('selecting a wallet enables the Connect Now button', async ({ page }) => {
+      await page.goto('/dashboard');
+      await page.getByRole('button', { name: /connect wallet/i }).click();
+      await page.getByText('Freighter').click();
+      await expect(page.getByRole('button', { name: /connect now/i })).toBeEnabled();
+    });
+
+    test('closing the modal hides it', async ({ page }) => {
+      await page.goto('/dashboard');
+      await page.getByRole('button', { name: /connect wallet/i }).click();
+      await expect(page.getByRole('dialog')).toBeVisible();
+      // Close via Escape key
+      await page.keyboard.press('Escape');
+      await expect(page.getByRole('dialog')).not.toBeVisible();
+    });
+
+    test('protected pages show connect wallet prompt when disconnected', async ({ page }) => {
+      const protectedPages = ['/payment-stream', '/offramp', '/distribution'];
+      for (const path of protectedPages) {
+        await page.goto(path);
+        await expect(page.getByRole('button', { name: /connect wallet/i })).toBeVisible();
+      }
+    });
+  });
+
+  test.describe('connected state', () => {
+    test.beforeEach(async ({ page }) => {
+      await injectConnectedWallet(page);
+    });
+
+    test('shows truncated address in navbar when connected', async ({ page }) => {
+      await page.goto('/dashboard');
+      // Address GAAAAAA...AWHF should be truncated as GAAA...AWHF
+      const truncated = `${MOCK_ADDRESS.slice(0, 4)}...${MOCK_ADDRESS.slice(-4)}`;
+      await expect(page.getByText(truncated)).toBeVisible();
+    });
+
+    test('does not show Connect Wallet button when connected', async ({ page }) => {
+      await page.goto('/dashboard');
+      await expect(page.getByRole('button', { name: /connect wallet/i })).not.toBeVisible();
+    });
+
+    test('clicking address shows disconnect option', async ({ page }) => {
+      await page.goto('/dashboard');
+      const truncated = `${MOCK_ADDRESS.slice(0, 4)}...${MOCK_ADDRESS.slice(-4)}`;
+      await page.getByText(truncated).click();
+      await expect(page.getByRole('menuitem', { name: /disconnect/i })).toBeVisible();
+    });
+
+    test('disconnecting clears address from navbar', async ({ page }) => {
+      await page.goto('/dashboard');
+      const truncated = `${MOCK_ADDRESS.slice(0, 4)}...${MOCK_ADDRESS.slice(-4)}`;
+      await page.getByText(truncated).click();
+      await page.getByRole('menuitem', { name: /disconnect/i }).click();
+      await expect(page.getByRole('button', { name: /connect wallet/i })).toBeVisible();
+    });
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@allbridge/bridge-core-sdk": "^3.29.1",
@@ -45,6 +47,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.48.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^20",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    // Inject mock wallet state into every page before scripts run
+    storageState: undefined,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});


### PR DESCRIPTION
Closes #26

---

feat(web): Add Playwright E2E test suite for critical user journeys

The project had zero end-to-end tests. A single broken import or missing provider could silently break an entire page with no automated safety net. This PR adds a full Playwright E2E suite covering every critical user flow.

What's changed
playwright.config.ts — Chromium, Next.js dev server as web server, CI-aware retries
mock-wallet.ts
 — shared helpers: injectConnectedWallet, clearWalletState, mockRpcCalls
navigation.spec.ts
 — root redirect, sidebar links, page load errors, 404 handling
wallet-connection.spec.ts
 — modal open/close, wallet list, connect/disconnect, protected route gates
payment-stream.spec.ts
 — form validation, duration preview, end time display, beta banner
distribution.spec.ts
 — recipient table, add/remove rows, CSV upload (valid + invalid), type toggle
history.spec.ts
 — filters, URL sync, date range, reset button, empty state
offramp.spec.ts
 — protected route, form render, info banners
Wallet mock strategy
No real browser extensions needed. page.addInitScript() injects localStorage keys before React boots, so StellarWalletProvider restores the session naturally. RPC calls are intercepted via page.route() — zero live network dependency.

How to run
cd apps/web
npm install
npx playwright install chromium
npm run test:e2e

close the issue #26 