### PR TITLE
feat: balance-aware amount validation

### DIFF
--- a/apps/web/src/app/(overview)/distribution/page.tsx
+++ b/apps/web/src/app/(overview)/distribution/page.tsx
@@ -10,6 +10,7 @@ import { Switch } from '@/components/ui/switch';
 import { Upload, Plus, Trash2 } from 'lucide-react';
 import { useDistributionState } from '@/hooks/use-distribution-state';
 import { useDistributionTransaction } from '@/hooks/use-distribution-transaction';
+import { useBalanceValidation } from '@/hooks/use-balance-validation';
 import { downloadCSVTemplate, processCSVFile } from '@/utils/csv-processing';
 import { SUPPORTED_TOKENS } from '@/lib/validations';
 import ProtectedRoute from '@/components/layouts/ProtectedRoute';
@@ -54,6 +55,20 @@ export default function DistributionPage() {
   const tokenAddress = React.useMemo(() => {
     return SUPPORTED_TOKENS.find((t) => t.value === selectedToken)?.address ?? 'native';
   }, [selectedToken]);
+
+  // Compute total amount for balance validation
+  const distributionTotal = React.useMemo(() => {
+    if (state.type === 'equal') return state.totalAmount;
+    // weighted: sum all recipient amounts
+    const sum = state.recipients.reduce((acc, r) => {
+      const n = parseFloat(r.amount || '0');
+      return acc + (isNaN(n) ? 0 : n);
+    }, 0);
+    return sum > 0 ? sum.toString() : '';
+  }, [state.type, state.totalAmount, state.recipients]);
+
+  const { balanceError: distBalanceError, insufficientBalance: distInsufficientBalance } =
+    useBalanceValidation(distributionTotal, selectedToken);
 
   const handleDistribute = async () => {
     await execute(state, tokenAddress);
@@ -461,23 +476,33 @@ export default function DistributionPage() {
 
             {/* Amount Configuration */}
             {state.type === 'equal' && (
-              <div className="flex items-center gap-2">
-                <Label className="text-sm whitespace-nowrap">
-                  Equal Amount per address
-                </Label>
-                <Input
-                  type="text"
-                  placeholder="Amount"
-                  value={state.totalAmount}
-                  onChange={(e) => setTotalAmount(e.target.value)}
-                  className="w-32"
-                />
+              <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-2">
+                  <Label className="text-sm whitespace-nowrap">
+                    Equal Amount per address
+                  </Label>
+                  <Input
+                    type="text"
+                    placeholder="Amount"
+                    value={state.totalAmount}
+                    onChange={(e) => setTotalAmount(e.target.value)}
+                    className={`w-32 ${distBalanceError ? 'border-red-500' : ''}`}
+                  />
+                </div>
+                {distBalanceError && (
+                  <p className="text-xs text-red-400">{distBalanceError}</p>
+                )}
               </div>
             )}
 
             {state.type === 'weighted' && (
-              <div className="flex items-center gap-2">
-                <Label className="text-sm">Amount</Label>
+              <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-2">
+                  <Label className="text-sm">Amount</Label>
+                </div>
+                {distBalanceError && (
+                  <p className="text-xs text-red-400">{distBalanceError}</p>
+                )}
               </div>
             )}
           </div>
@@ -586,7 +611,7 @@ export default function DistributionPage() {
 
           <Button
             className="bg-purple-600 hover:bg-purple-700"
-            disabled={state.recipients.length === 0 || isSubmitting}
+            disabled={state.recipients.length === 0 || isSubmitting || distInsufficientBalance}
             onClick={handleDistribute}
           >
             {isSubmitting ? 'Distributing...' : 'Distribute Token'}

--- a/apps/web/src/components/modules/payment-stream/CreatePaymentStream.tsx
+++ b/apps/web/src/components/modules/payment-stream/CreatePaymentStream.tsx
@@ -13,6 +13,7 @@ import { SUPPORTED_TOKENS, PaymentStreamFormData } from "@/lib/validations";
 import { StellarService } from "@/lib/stellar";
 import { validateEndTime } from "@/lib/stream-validation";
 import { useDebouncedCallback } from "@/hooks/use-debounce-callback";
+import { useBalanceValidation } from "@/hooks/use-balance-validation";
 import { createTestnetService } from "@/services/stellar.service";
 import { PAYMENT_STREAM_CONTRACT_ID, DISTRIBUTOR_CONTRACT_ID } from "@/lib/constants";
 
@@ -70,6 +71,11 @@ const CreatePaymentStream = () => {
     const selectedToken = useMemo(() => {
         return SUPPORTED_TOKENS.find((t) => t.value === streamData.token);
     }, [streamData.token]);
+
+    const { balanceError, insufficientBalance } = useBalanceValidation(
+        streamData.amount,
+        streamData.token
+    );
 
     const estimateFee = useDebouncedCallback(async (data: StreamFormData, userAddress: string) => {
         if (!data.recipient || !data.amount || !data.durationValue || !StellarService.validateStellarAddress(data.recipient)) {
@@ -238,6 +244,8 @@ const CreatePaymentStream = () => {
                             durationOptions={durationOptions}
                             onSubmit={handleFormSubmit}
                             isSubmitting={isSubmitting}
+                            balanceError={balanceError}
+                            insufficientBalance={insufficientBalance}
                         />
                     </div>
                 </div>

--- a/apps/web/src/components/modules/payment-stream/PaymentStreamForm.tsx
+++ b/apps/web/src/components/modules/payment-stream/PaymentStreamForm.tsx
@@ -32,6 +32,8 @@ interface StreamFormProps {
   durationOptions: { label: string; value: string }[];
   onSubmit: () => void;
   isSubmitting: boolean;
+  balanceError?: string | null;
+  insufficientBalance?: boolean;
 }
 
 export function PaymentStreamForm({
@@ -41,6 +43,8 @@ export function PaymentStreamForm({
   durationOptions,
   onSubmit,
   isSubmitting,
+  balanceError,
+  insufficientBalance,
 }: StreamFormProps) {
   const booleanOptions = [
     { label: "Yes", value: "true" },
@@ -75,6 +79,7 @@ export function PaymentStreamForm({
 
   const isFormValid =
     !isSubmitting &&
+    !insufficientBalance &&
     streamData.name &&
     streamData.durationValue &&
     streamData.recipient &&
@@ -100,6 +105,7 @@ export function PaymentStreamForm({
             placeholder="Enter total amount to stream"
             value={streamData.amount}
             onChange={(e) => handleStreamDataChange("amount", e.target.value)}
+            errorMessage={balanceError ?? undefined}
           />
         </div>
 

--- a/apps/web/src/hooks/use-balance-validation.ts
+++ b/apps/web/src/hooks/use-balance-validation.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect, useRef } from "react";
+import { useTokenBalance } from "./use-token-balance";
+
+/**
+ * Debounced balance validation hook.
+ *
+ * Compares an input amount against the user's on-chain balance for the
+ * selected token. Returns an inline error string when the input exceeds
+ * the balance, and an `insufficientBalance` flag to disable submit.
+ */
+export function useBalanceValidation(
+  amount: string,
+  tokenCode: string | undefined,
+  delay = 300
+) {
+  const { balance, isLoading } = useTokenBalance(tokenCode);
+  const [error, setError] = useState<string | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    // Clear immediately when input is empty
+    if (!amount || !balance) {
+      setError(null);
+      return;
+    }
+
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+
+    timeoutRef.current = setTimeout(() => {
+      const inputNum = parseFloat(amount);
+      const balanceNum = parseFloat(balance);
+
+      if (isNaN(inputNum) || inputNum <= 0) {
+        setError(null);
+        return;
+      }
+
+      if (inputNum > balanceNum) {
+        setError(
+          `Insufficient ${tokenCode} balance. Available: ${balance}`
+        );
+      } else {
+        setError(null);
+      }
+    }, delay);
+
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [amount, balance, tokenCode, delay]);
+
+  return {
+    balanceError: error,
+    insufficientBalance: !!error,
+    isLoadingBalance: isLoading,
+    availableBalance: balance,
+  };
+}

--- a/apps/web/src/hooks/use-token-balance.ts
+++ b/apps/web/src/hooks/use-token-balance.ts
@@ -1,0 +1,64 @@
+import { useQuery } from "@tanstack/react-query";
+import { useWallet } from "@/providers/StellarWalletProvider";
+import { StellarService } from "@/services/stellar.service";
+import { extractBalances } from "@/services/transform-balances";
+import { WalletNetwork } from "@creit.tech/stellar-wallets-kit";
+import type { TokenBalanceData } from "@/types/token-balance.types";
+
+/**
+ * Hook that fetches and caches token balances for the connected wallet.
+ * Shares the same react-query cache key as TokenBalanceList so data is
+ * never fetched twice.
+ */
+export function useTokenBalances() {
+  const { address, isConnected, network } = useWallet();
+
+  const { data: balances, isLoading, error } = useQuery<TokenBalanceData[] | null>({
+    queryKey: ["token-balances", address, network],
+    queryFn: async ({ signal }) => {
+      if (!address) return null;
+
+      const isTestnet = network === WalletNetwork.TESTNET;
+      const stellarService = new StellarService({
+        network: {
+          networkPassphrase: isTestnet
+            ? "Test SDF Network ; September 2015"
+            : "Public Global Stellar Network ; September 2015",
+          rpcUrl: isTestnet
+            ? "https://soroban-testnet.stellar.org"
+            : "https://soroban.stellar.org",
+          horizonUrl: isTestnet
+            ? "https://horizon-testnet.stellar.org"
+            : "https://horizon.stellar.org",
+        },
+        contracts: { paymentStream: "", distributor: "" },
+      });
+
+      const accountInfo = await stellarService.getAccount(address, signal);
+      return extractBalances(accountInfo);
+    },
+    enabled: isConnected && !!address,
+    staleTime: 15_000,
+    refetchInterval: 30_000,
+    refetchIntervalInBackground: false,
+    retry: 2,
+  });
+
+  return { balances: balances ?? [], isLoading, error };
+}
+
+/**
+ * Returns the balance string for a given token code (e.g. "XLM", "USDC").
+ * Returns null while loading or if the token isn't held.
+ */
+export function useTokenBalance(tokenCode: string | undefined) {
+  const { balances, isLoading } = useTokenBalances();
+
+  if (!tokenCode || isLoading) return { balance: null, isLoading };
+
+  const entry = balances.find(
+    (b) => b.assetCode.toUpperCase() === tokenCode.toUpperCase()
+  );
+
+  return { balance: entry?.balance ?? null, isLoading };
+}


### PR DESCRIPTION
## Summary
- Adds `useTokenBalance` hook that fetches and caches on-chain balances via react-query (shares cache with `TokenBalanceList`)
- Adds `useBalanceValidation` hook with debounced (300ms) comparison of input amount vs available balance
- Wires validation into **PaymentStreamForm**: inline error on amount field + submit disabled when insufficient
- Wires validation into **Distribution page**: validates total amount (equal) or sum of recipient amounts (weighted), shows inline error, disables distribute button

## Test plan
- [ ] Connect wallet with known balances
- [ ] On Create Stream, enter an amount exceeding the selected token's balance — verify inline error appears after ~300ms and Proceed button is disabled
- [ ] Change token selection — verify error updates for the new token's balance
- [ ] Enter a valid amount below balance — verify no error and button is enabled
- [ ] On Distribution (equal), enter a total amount exceeding balance — verify inline error and disabled button
- [ ] On Distribution (weighted), add recipients whose amounts sum above balance — verify inline error
- [ ] Verify no duplicate network requests (balance query shares cache with sidebar TokenBalanceList)

Closes #27


