### PR TITLE
fix: destructure primitive deps in usePagination to prevent infinite …

### DIFF
--- a/apps/web/src/hooks/use-pagination.ts
+++ b/apps/web/src/hooks/use-pagination.ts
@@ -65,5 +65,8 @@ export const getPaginationRange = ({
   return items;
 };
 
-export const usePagination = (params: UsePaginationParams) =>
-  useMemo(() => getPaginationRange(params), [params]);
+export const usePagination = ({ currentPage, pageCount, siblingCount = 2 }: UsePaginationParams) =>
+  useMemo(
+    () => getPaginationRange({ currentPage, pageCount, siblingCount }),
+    [currentPage, pageCount, siblingCount]
+  );


### PR DESCRIPTION
Problem                                                                                  
                                                                                           
  usePagination passed the params object directly as a useMemo dependency. Since a new     
  object is created on every render, React's reference equality check always fails, causing
  useMemo to recompute on every render and triggering infinite re-renders in consumers.    
                                                                                           
  Solution                                                                                 
                                                                                           
  Destructured currentPage, pageCount, and siblingCount as individual parameters and used  
  those primitive values in the dependency array. React compares primitives by value, so   
  useMemo now only recomputes when the actual values change.                               
                                                                                           
  Changes                                                                                  
                                                                                           
  - apps/web/src/hooks/use-pagination.ts — destructure params, replace [params] dep with   
  [currentPage, pageCount, siblingCount]                                                   
                                                                                           
  Closes #124          