### PR TITLE
perf(history): debounce URL filter sync to prevent excessive calls

### DIFF
--- a/apps/web/src/app/(overview)/history/page.tsx
+++ b/apps/web/src/app/(overview)/history/page.tsx
@@ -1,5 +1,5 @@
 "use client";
- 
+
 import React, { useState, useMemo, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
@@ -14,6 +14,7 @@ import AppSelect from "@/components/molecules/AppSelect";
 import { createTestnetService } from "@/services";
 import { DISTRIBUTOR_CONTRACT_ID, PAYMENT_STREAM_CONTRACT_ID } from "@/lib/constants";
 import { withAbortSignal } from "@/utils/retry";
+import { useDebouncedCallback } from "@/hooks/use-debounce-callback";
 
 const HistoryPage = () => {
     const { address } = useWallet();
@@ -32,7 +33,15 @@ const HistoryPage = () => {
     const [startDate, setStartDate] = useState(searchParams.get("from") || '');
     const [endDate, setEndDate] = useState(searchParams.get("to") || '');
 
-    // Sync state with URL
+    const syncUrlParams = useDebouncedCallback(
+        (p: URLSearchParams) => {
+            const query = p.toString();
+            router.replace(`${pathname}${query ? `?${query}` : ""}`, { scroll: false });
+        },
+        300
+    );
+
+    // Sync state with URL (debounced 300ms to prevent excessive calls on date input)
     useEffect(() => {
         const params = new URLSearchParams();
         if (page > 1) params.set("page", page.toString());
@@ -43,9 +52,8 @@ const HistoryPage = () => {
         if (startDate) params.set("from", startDate);
         if (endDate) params.set("to", endDate);
 
-        const query = params.toString();
-        router.replace(`${pathname}${query ? `?${query}` : ""}`, { scroll: false });
-    }, [page, limit, typeFilter, tokenFilter, statusFilter, startDate, endDate, router, pathname]);
+        syncUrlParams(params);
+    }, [page, limit, typeFilter, tokenFilter, statusFilter, startDate, endDate, syncUrlParams]);
 
     const service = useMemo(() => createTestnetService({
         paymentStream: PAYMENT_STREAM_CONTRACT_ID,


### PR DESCRIPTION
Summary

Wraps the URL sync useEffect in apps/web/src/app/(overview)/history/page.tsx with useDebouncedCallback (300ms delay)
Uses the existing useDebouncedCallback hook at apps/web/src/hooks/use-debounce-callback.ts — no new dependencies added
Filter state still updates immediately (fast UI feedback); only the router.replace call is debounced, so rapid date input no longer fires the URL update on every keystroke
Closes #123 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved URL synchronization performance on the history page by debouncing state updates when filters, pagination, or date selections change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->