### PR TITLE
fix: add 10s timeout to accountExists to prevent indefinite hang

### DIFF
--- a/apps/web/src/hooks/use-distribution-transaction.ts
+++ b/apps/web/src/hooks/use-distribution-transaction.ts
@@ -14,15 +14,33 @@ const HORIZON_URL = IS_MAINNET
   ? 'https://horizon.stellar.org'
   : 'https://horizon-testnet.stellar.org';
 
+const ACCOUNT_CHECK_TIMEOUT_MS = 10_000;
+
+/**
+ * Rejects after a given number of milliseconds with a timeout error.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`Timeout checking account: ${label}`)), ms)
+    ),
+  ]);
+}
+
 /**
  * Checks if an account exists on the Stellar network.
+ * Rejects with a timeout error if the account does not respond within ACCOUNT_CHECK_TIMEOUT_MS.
  */
 async function accountExists(address: string): Promise<boolean> {
   try {
     const horizon = new Horizon.Server(HORIZON_URL, { allowHttp: true });
-    await horizon.loadAccount(address);
+    await withTimeout(horizon.loadAccount(address), ACCOUNT_CHECK_TIMEOUT_MS, address);
     return true;
-  } catch {
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith('Timeout checking account:')) {
+      throw err;
+    }
     return false;
   }
 }
@@ -101,7 +119,14 @@ export function useDistributionTransaction() {
 
       // Pre-flight: check all recipient accounts exist
       notify.loading('Validating recipients...');
-      const existenceChecks = await Promise.all(recipients.map(accountExists));
+      let existenceChecks: boolean[];
+      try {
+        existenceChecks = await Promise.all(recipients.map(accountExists));
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Account validation timed out';
+        notify.error(msg);
+        return false;
+      }
       const missingIndex = existenceChecks.findIndex((exists) => !exists);
       if (missingIndex !== -1) {
         notify.error(


### PR DESCRIPTION
Close #128 

**fix: add 10s timeout to `accountExists` to prevent indefinite hang**

**Problem**

The `accountExists` check in `use-distribution-transaction.ts` had no timeout. If a Horizon node was slow or unresponsive, the validation step would hang indefinitely, blocking the entire distribution flow with no feedback to the user.

**Solution**

- Added a `withTimeout` helper that races any promise against a configurable timer
- `accountExists` now times out after 10 seconds per account and throws a descriptive error
- The call site catches timeout errors and surfaces a clear message to the user, failing fast instead of hanging

**Changes**

- `apps/web/src/hooks/use-distribution-transaction.ts`

**Testing**

Simulate a slow/unresponsive account by throttling the network or mocking `horizon.loadAccount` to never resolve — the distribution should fail within 10 seconds with a timeout error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened account validation with timeout protection for each recipient. When validation times out, users receive clear error notifications and submission is blocked, ensuring validation issues are identified and resolved before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->