### PR TITLE
Fix/csv dropzone keyboard accessibility

### DIFF
--- a/apps/web/src/app/(overview)/distribution/page.tsx
+++ b/apps/web/src/app/(overview)/distribution/page.tsx
@@ -17,6 +17,7 @@ import ProtectedRoute from '@/components/layouts/ProtectedRoute';
 import { CSVErrorDisplay } from '@/components/molecules/CSVErrorDisplay';
 import { CSVError, CSVWarning } from '@/types/distribution';
 import { useVirtualizer } from '@tanstack/react-virtual';
+import { Skeleton } from '@/components/ui/skeleton';
 import { notify } from '@/utils/notification';
 import { ErrorBoundary } from '@/components/ui/error-boundary';
 import { ErrorFallback } from '@/components/ui/error-fallback';
@@ -467,6 +468,35 @@ export default function DistributionPage() {
   const shouldVirtualize = state.recipients.length >= VIRTUALIZE_THRESHOLD;
   const RecipientTableComponent = shouldVirtualize ? VirtualizedRecipientTable : StandardRecipientTable;
 
+  const SKELETON_ROW_COUNT = 5;
+
+  const RecipientTableSkeleton = () => (
+    <div className="border border-zinc-800 rounded-lg mb-6 bg-zinc-900/30">
+      <Table>
+        <TableHeader className="sticky top-0 bg-zinc-900/90 backdrop-blur-sm z-10">
+          <TableRow className="border-zinc-800">
+            <TableHead className="w-12 text-zinc-400">#</TableHead>
+            <TableHead className="text-zinc-400">Address</TableHead>
+            <TableHead className="w-24 text-right text-zinc-400">
+              {state.type === 'weighted' ? 'Amount' : '0'}
+            </TableHead>
+            <TableHead className="w-12"></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {Array.from({ length: SKELETON_ROW_COUNT }).map((_, i) => (
+            <TableRow key={i} className="border-zinc-800">
+              <TableCell><Skeleton className="h-4 w-4 bg-zinc-800" /></TableCell>
+              <TableCell><Skeleton className="h-4 w-full bg-zinc-800/60" /></TableCell>
+              <TableCell className="text-right"><Skeleton className="h-4 w-12 ml-auto bg-zinc-800/60" /></TableCell>
+              <TableCell><Skeleton className="h-6 w-6 rounded bg-zinc-800/40" /></TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+
   return (
     <ProtectedRoute description="Connect your Stellar wallet to create token distributions.">
       <ErrorBoundary
@@ -666,10 +696,18 @@ export default function DistributionPage() {
 
         {/* Recipients Table */}
         <div className="relative">
-          <RecipientTableComponent />
+          {isProcessing ? (
+            <>
+              <p className="text-sm text-zinc-400 mb-2 flex items-center gap-2">
+                <span className="inline-block h-2 w-2 rounded-full bg-purple-500 animate-pulse" />
+                Validating recipients...
+              </p>
+              <RecipientTableSkeleton />
+            </>
+          ) : (
+            <RecipientTableComponent />
+          )}
         </div>
-        
-        {/* Scroll indicator for large lists - Removed as table is full height */}
 
         {/* Action Buttons */}
         <div className="flex justify-between">

--- a/apps/web/src/app/(overview)/distribution/page.tsx
+++ b/apps/web/src/app/(overview)/distribution/page.tsx
@@ -654,9 +654,20 @@ export default function DistributionPage() {
 
         {/* CSV Upload Area */}
         <div
-          className="border-2 border-dashed border-zinc-700 rounded-lg p-8 mb-6 text-center bg-zinc-900/50"
+          role="button"
+          tabIndex={isProcessing ? -1 : 0}
+          aria-label="CSV upload area. Drag and drop a CSV file here, or press Enter or Space to open the file picker."
+          aria-disabled={isProcessing}
+          className="border-2 border-dashed border-zinc-700 rounded-lg p-8 mb-6 text-center bg-zinc-900/50 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:border-purple-500"
           onDragOver={handleDragOver}
           onDrop={handleDrop}
+          onClick={!isProcessing ? handleSelectFile : undefined}
+          onKeyDown={(e) => {
+            if (!isProcessing && (e.key === 'Enter' || e.key === ' ')) {
+              e.preventDefault();
+              handleSelectFile();
+            }
+          }}
         >
           <div className="flex flex-col items-center gap-4">
             <Upload className="h-12 w-12 text-zinc-500" />
@@ -665,6 +676,7 @@ export default function DistributionPage() {
               <p className="text-sm text-zinc-500">
                 CSV format: {state.type === 'equal' ? 'address (one per line)' : 'address,amount (one per line)'}
               </p>
+              <p className="text-xs text-zinc-600 mt-1">Keyboard: Tab to focus, Enter or Space to open file picker</p>
             </div>
             <div className="flex gap-2">
               <input
@@ -677,14 +689,14 @@ export default function DistributionPage() {
               />
               <Button 
                 variant="outline" 
-                onClick={handleSelectFile}
+                onClick={(e) => { e.stopPropagation(); handleSelectFile(); }}
                 disabled={isProcessing}
               >
                 {isProcessing ? 'Processing...' : 'Select File'}
               </Button>
               <Button 
                 variant="outline" 
-                onClick={handleDownloadTemplate}
+                onClick={(e) => { e.stopPropagation(); handleDownloadTemplate(); }}
                 className="text-purple-400 border-purple-400 hover:bg-purple-400/10"
                 disabled={isProcessing}
               >

--- a/apps/web/src/hooks/use-distribution-transaction.ts
+++ b/apps/web/src/hooks/use-distribution-transaction.ts
@@ -14,15 +14,33 @@ const HORIZON_URL = IS_MAINNET
   ? 'https://horizon.stellar.org'
   : 'https://horizon-testnet.stellar.org';
 
+const ACCOUNT_CHECK_TIMEOUT_MS = 10_000;
+
+/**
+ * Rejects after a given number of milliseconds with a timeout error.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`Timeout checking account: ${label}`)), ms)
+    ),
+  ]);
+}
+
 /**
  * Checks if an account exists on the Stellar network.
+ * Rejects with a timeout error if the account does not respond within ACCOUNT_CHECK_TIMEOUT_MS.
  */
 async function accountExists(address: string): Promise<boolean> {
   try {
     const horizon = new Horizon.Server(HORIZON_URL, { allowHttp: true });
-    await horizon.loadAccount(address);
+    await withTimeout(horizon.loadAccount(address), ACCOUNT_CHECK_TIMEOUT_MS, address);
     return true;
-  } catch {
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith('Timeout checking account:')) {
+      throw err;
+    }
     return false;
   }
 }
@@ -101,7 +119,14 @@ export function useDistributionTransaction() {
 
       // Pre-flight: check all recipient accounts exist
       notify.loading('Validating recipients...');
-      const existenceChecks = await Promise.all(recipients.map(accountExists));
+      let existenceChecks: boolean[];
+      try {
+        existenceChecks = await Promise.all(recipients.map(accountExists));
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Account validation timed out';
+        notify.error(msg);
+        return false;
+      }
       const missingIndex = existenceChecks.findIndex((exists) => !exists);
       if (missingIndex !== -1) {
         notify.error(


### PR DESCRIPTION
Close #136 

**fix: add keyboard accessibility to CSV drag-and-drop zone**

**Problem**

The CSV upload drop zone had no keyboard support. Users who can't use a mouse had no way to discover or interact with it — no focus indicator, no keyboard trigger, and no instructions. The only alternative was a visually hidden file input.

**Solution**

- Added `role="button"` and `tabIndex={0}` so the drop zone is reachable via Tab
- Enter or Space now opens the file picker via `onKeyDown`
- Clicking anywhere on the zone also opens the file picker
- Added `focus-visible:ring-2 focus-visible:ring-purple-500` for a clear visible focus indicator
- Added `aria-label` with full instructions for screen readers
- Added a visible keyboard hint below the format text for sighted keyboard users
- Drop zone becomes non-interactive (`tabIndex={-1}`, no click) while processing
- Added `e.stopPropagation()` to the inner buttons to prevent double-triggering the file picker

**Changes**

- `apps/web/src/app/(overview)/distribution/page.tsx`

**Testing**

Tab to the drop zone — a purple focus ring should appear. Press Enter or Space — the file picker should open. Verify clicking anywhere on the zone also opens the picker. Confirm the "Select File" and "Download Template" buttons still work independently without opening the picker twice.