### PR TITLE
fix: correct getQuoteStatus API path to use OFFRAMP_API_BASE

### DIFF
--- a/apps/web/src/services/offramp.service.ts
+++ b/apps/web/src/services/offramp.service.ts
@@ -289,7 +289,7 @@ const realOfframpService = {
     ): Promise<QuoteStatusResponse> {
         try {
             const res = await fetchWithRetry(
-                `${API_BASE}/api/webhook/quote/${transactionReference}`,
+                `${OFFRAMP_API_BASE}/quote/${transactionReference}`,
                 {
                     method: "GET",
                     headers: getHeaders(walletId),


### PR DESCRIPTION
Close #113 

**fix: correct `getQuoteStatus` API path to use consistent base URL**

**Problem**

`getQuoteStatus` was calling `/api/webhook/quote/{transactionReference}` while every other endpoint in the service uses `${OFFRAMP_API_BASE}` (`/api/offramp/...`). This inconsistency would cause 404 errors in production when polling quote status.

**Solution**

Replaced `${API_BASE}/api/webhook/quote/${transactionReference}` with `${OFFRAMP_API_BASE}/quote/${transactionReference}`, aligning it with the rest of the offramp service endpoints.

**Changes**

- `apps/web/src/services/offramp.service.ts` — line 292, one-line fix

**Testing**

Trigger an offramp quote flow and verify the quote status polling returns a valid response instead of a 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal API endpoint routing for quote status requests while maintaining consistent request handling and response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->