### PR TITLE
fix: make account number validation dynamic per country

### DIFF
--- a/apps/web/src/components/offramp/BankDetailsCard.tsx
+++ b/apps/web/src/components/offramp/BankDetailsCard.tsx
@@ -6,6 +6,7 @@ import { Label } from "@/components/ui/label";
 import { Loader2, CheckCircle2, ChevronDown, Search } from "lucide-react";
 
 import type { OfframpFormState, Bank } from "@/types/offramp";
+import { getAccountNumberRules } from "@/types/offramp";
 
 interface BankDetailsCardProps {
     formState: OfframpFormState;
@@ -141,6 +142,7 @@ export default function BankDetailsCard({
     isVerifyingAccount,
     onChange,
 }: BankDetailsCardProps) {
+    const { max: maxLen } = getAccountNumberRules(formState.country);
     return (
         <div className="bg-fundable-mid-dark rounded-2xl p-6 border border-gray-800">
             <h2 className="text-xl font-syne font-semibold text-white mb-6">
@@ -170,11 +172,11 @@ export default function BankDetailsCard({
                             placeholder="Enter account number"
                             value={formState.accountNumber}
                             onChange={(e) => {
-                                const value = e.target.value.replace(/\D/g, "").slice(0, 10);
+                                const value = e.target.value.replace(/\D/g, "").slice(0, maxLen);
                                 onChange("accountNumber", value);
                             }}
                             className="bg-fundable-dark border-gray-700 text-white h-12"
-                            maxLength={10}
+                            maxLength={maxLen}
                         />
                         {isVerifyingAccount && (
                             <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-fundable-purple" />

--- a/apps/web/src/components/offramp/BankSelector.tsx
+++ b/apps/web/src/components/offramp/BankSelector.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import type { Bank, OfframpCountry } from "@/types/offramp";
+import { getAccountNumberRules } from "@/types/offramp";
 import { offrampService } from "@/services/offramp.service";
 import { notify } from "@/utils/notification";
 
@@ -32,6 +33,8 @@ export function BankSelector({
     const [verifyError, setVerifyError] = useState<string | null>(null);
     const [searchTerm, setSearchTerm] = useState("");
 
+    const { min: minLen, max: maxLen } = getAccountNumberRules(country);
+
     // Load banks when country changes
     useEffect(() => {
         const loadBanks = async () => {
@@ -52,7 +55,7 @@ export function BankSelector({
 
     // Auto-verify account when both bank and account number are valid
     const verifyAccount = useCallback(async () => {
-        if (!selectedBankCode || accountNumber.length < 10) return;
+        if (!selectedBankCode || accountNumber.length < minLen) return;
 
         setIsVerifying(true);
         setVerifyError(null);
@@ -77,10 +80,10 @@ export function BankSelector({
         } finally {
             setIsVerifying(false);
         }
-    }, [selectedBankCode, accountNumber, country, walletAddress, onAccountVerified]);
+    }, [selectedBankCode, accountNumber, country, walletAddress, onAccountVerified, minLen]);
 
     useEffect(() => {
-        if (selectedBankCode && accountNumber.length >= 10) {
+        if (selectedBankCode && accountNumber.length >= minLen) {
             const timer = setTimeout(verifyAccount, 500);
             return () => clearTimeout(timer);
         }
@@ -145,8 +148,8 @@ export function BankSelector({
                 <input
                     type="text"
                     inputMode="numeric"
-                    maxLength={10}
-                    placeholder="Enter 10-digit account number"
+                    maxLength={maxLen}
+                    placeholder={`Enter ${minLen === maxLen ? `${minLen}-digit` : `${minLen}-${maxLen} digit`} account number`}
                     value={accountNumber}
                     onChange={(e) => {
                         const val = e.target.value.replace(/\D/g, "");

--- a/apps/web/src/components/offramp/OfframpSummary.tsx
+++ b/apps/web/src/components/offramp/OfframpSummary.tsx
@@ -5,7 +5,7 @@ import { Loader2 } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 
 import type { OfframpFormState, ProviderRate } from "@/types/offramp";
-import { SUPPORTED_COUNTRIES, getCurrencySymbol } from "@/types/offramp";
+import { SUPPORTED_COUNTRIES, getCurrencySymbol, getAccountNumberRules } from "@/types/offramp";
 
 interface OfframpSummaryProps {
     formState: OfframpFormState;
@@ -29,7 +29,7 @@ export default function OfframpSummary({
         formState.amount &&
         parseFloat(formState.amount) > 0 &&
         formState.bankCode &&
-        formState.accountNumber.length >= 10 &&
+        formState.accountNumber.length >= getAccountNumberRules(formState.country).min &&
         formState.accountName;
 
     const canProceed = isFormValid && quote && !isLoading;

--- a/apps/web/src/hooks/useOfframpBridge.ts
+++ b/apps/web/src/hooks/useOfframpBridge.ts
@@ -12,7 +12,7 @@ import type {
     OfframpCountry,
     ProviderRate,
 } from "@/types/offramp";
-import { SUPPORTED_OFFRAMP_TOKENS } from "@/types/offramp";
+import { SUPPORTED_OFFRAMP_TOKENS, getAccountNumberRules } from "@/types/offramp";
 
 interface UseOfframpBridgeReturn {
     // State
@@ -153,7 +153,7 @@ export function useOfframpBridge(): UseOfframpBridgeReturn {
     // ---------- Effects: Account Verification ----------
 
     useEffect(() => {
-        if (!formState.bankCode || formState.accountNumber.length < 10) {
+        if (!formState.bankCode || formState.accountNumber.length < getAccountNumberRules(formState.country).min) {
             setFormState(prev => ({ ...prev, accountName: "" }));
             return;
         }

--- a/apps/web/src/types/offramp.ts
+++ b/apps/web/src/types/offramp.ts
@@ -27,6 +27,16 @@ export const SUPPORTED_COUNTRIES: CountryInfo[] = [
     { code: "KE", name: "Kenya", currency: "KES", flag: "🇰🇪" },
 ];
 
+export const ACCOUNT_NUMBER_RULES: Record<OfframpCountry, { min: number; max: number }> = {
+    NG: { min: 10, max: 10 },
+    GH: { min: 10, max: 16 },
+    KE: { min: 6, max: 16 },
+};
+
+export function getAccountNumberRules(country: OfframpCountry) {
+    return ACCOUNT_NUMBER_RULES[country] ?? { min: 6, max: 16 };
+}
+
 // Supported crypto tokens
 export type OfframpToken = "USDC" | "USDT";
 


### PR DESCRIPTION
Hardcoded 10-digit limit broke offramp for Kenyan banks (6-16 digits).
Added per-country rules and replaced all hardcoded length checks.

closes #121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account number fields now validate based on country-specific length requirements instead of a fixed threshold, allowing appropriate input constraints for different regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->