### PR TITLE
I implemented the [SDK] Add support for Address objects in client parameters

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,11 +1,16 @@
 # @fundable/sdk
 
+## 0.2.0
+
+### Minor Changes
+
+- **Address Object Support**: All client methods now accept `@stellar/stellar-sdk` `Address` objects in addition to string addresses for better type safety and consistency with the Stellar SDK
+
 ## 0.1.0
 
 ### Minor Changes
 
 - Initial release of the Fundable Stellar SDK
-
   - `PaymentStreamClient` — create, withdraw, pause, resume, and cancel payment streams
   - `DistributorClient` — equal and weighted token distribution to multiple recipients
   - `ContractDeployer` — deploy Fundable contracts to Stellar networks

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -24,6 +24,45 @@ This SDK has a peer dependency on `@stellar/stellar-sdk`. You will need to have 
 pnpm add @stellar/stellar-sdk
 ```
 
+## Address Support
+
+All SDK methods that accept address parameters now support both string addresses and `@stellar/stellar-sdk` `Address` objects. This provides better type safety and consistency with the underlying Stellar SDK.
+
+**Example:**
+
+```typescript
+import { PaymentStreamClient, Address } from "@fundable/sdk";
+import { Address as StellarAddress } from "@stellar/stellar-sdk";
+
+const client = new PaymentStreamClient(config);
+
+// Using string addresses (still supported)
+const tx1 = await client.createStream({
+  sender: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  recipient: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+  token: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+  // ... other params
+});
+
+// Using Address objects (new feature)
+const senderAddress = new StellarAddress(
+  "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+);
+const recipientAddress = new StellarAddress(
+  "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+);
+const tokenAddress = new StellarAddress(
+  "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+);
+
+const tx2 = await client.createStream({
+  sender: senderAddress,
+  recipient: recipientAddress,
+  token: tokenAddress,
+  // ... other params
+});
+```
+
 ---
 
 ## API Reference (Under Development)
@@ -34,20 +73,20 @@ The SDK provides client classes for interacting with the deployed smart contract
 
 The `PaymentStreamClient` provides methods for interacting with the `payment-stream` contract.
 
--   **`createStream(...)`**: Create a new payment stream.
--   **`getStream(...)`**: Retrieve stream details.
--   **`withdrawableAmount(...)`**: Calculate the withdrawable amount for a stream.
--   **`withdraw(...)`**: Withdraw from a stream.
--   **`pauseStream(...)`**: Pause a stream.
--   **`resumeStream(...)`**: Resume a stream.
--   **`cancelStream(...)`**: Cancel a stream.
+- **`createStream(...)`**: Create a new payment stream.
+- **`getStream(...)`**: Retrieve stream details.
+- **`withdrawableAmount(...)`**: Calculate the withdrawable amount for a stream.
+- **`withdraw(...)`**: Withdraw from a stream.
+- **`pauseStream(...)`**: Pause a stream.
+- **`resumeStream(...)`**: Resume a stream.
+- **`cancelStream(...)`**: Cancel a stream.
 
 ### `DistributorClient`
 
 The `DistributorClient` provides methods for interacting with the `distributor` contract.
 
--   **`distributeEqual(...)`**: Distribute tokens equally to a list of recipients.
--   **`distributeWeighted(...)`**: Distribute tokens with weighted amounts to a list of recipients.
+- **`distributeEqual(...)`**: Distribute tokens equally to a list of recipients.
+- **`distributeWeighted(...)`**: Distribute tokens with weighted amounts to a list of recipients.
 
 ### Transaction Utilities
 
@@ -56,6 +95,7 @@ The `DistributorClient` provides methods for interacting with the `distributor` 
 Waits for an `AssembledTransaction` to be confirmed on-chain. This simplifies the UX for developers by automatically handling polling and confirmation.
 
 **Features:**
+
 - Automatic polling with configurable intervals
 - Timeout protection (default: 60 seconds)
 - Progress tracking with optional callbacks
@@ -63,6 +103,7 @@ Waits for an `AssembledTransaction` to be confirmed on-chain. This simplifies th
 - Full TypeScript support
 
 **Example:**
+
 ```typescript
 import { PaymentStreamClient, waitForTransaction } from "@fundable/sdk";
 
@@ -73,7 +114,10 @@ await tx.signAndSend({
   signTransaction: (xdr) => wallet.signTransaction(xdr),
 });
 
-const result = await waitForTransaction(tx, "https://soroban-testnet.stellar.org");
+const result = await waitForTransaction(
+  tx,
+  "https://soroban-testnet.stellar.org"
+);
 console.log(`Stream created with ID: ${result.result}`);
 console.log(`Confirmed on ledger: ${result.ledger}`);
 ```
@@ -83,6 +127,7 @@ console.log(`Confirmed on ledger: ${result.ledger}`);
 Convenience method that combines `signAndSend` with `waitForTransaction` in a single call.
 
 **Example:**
+
 ```typescript
 import { PaymentStreamClient, signAndWait } from "@fundable/sdk";
 
@@ -92,7 +137,7 @@ const tx = await client.createStream(params);
 const result = await signAndWait(
   tx,
   "https://soroban-testnet.stellar.org",
-  (xdr) => wallet.signTransaction(xdr),
+  (xdr) => wallet.signTransaction(xdr)
 );
 
 console.log(`Stream created with ID: ${result.result}`);
@@ -108,15 +153,15 @@ The `Stream` interface represents the data structure for a payment stream.
 
 ```typescript
 export interface Stream {
-    id: bigint;
-    sender: string;
-    recipient: string;
-    token: string;
-    totalAmount: bigint;
-    withdrawnAmount: bigint;
-    startTime: bigint;
-    endTime: bigint;
-    status: "Active" | "Paused" | "Canceled" | "Completed";
+  id: bigint;
+  sender: string;
+  recipient: string;
+  token: string;
+  totalAmount: bigint;
+  withdrawnAmount: bigint;
+  startTime: bigint;
+  endTime: bigint;
+  status: "Active" | "Paused" | "Canceled" | "Completed";
 }
 ```
 
@@ -125,10 +170,7 @@ export interface Stream {
 Here's how to use the SDK to create a payment stream and wait for confirmation:
 
 ```typescript
-import {
-  PaymentStreamClient,
-  signAndWait,
-} from "@fundable/sdk";
+import { PaymentStreamClient, signAndWait } from "@fundable/sdk";
 
 const client = new PaymentStreamClient({
   contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
@@ -152,7 +194,7 @@ async function createAndConfirmStream() {
   const result = await signAndWait(
     tx,
     "https://soroban-testnet.stellar.org",
-    (xdr) => wallet.signTransaction(xdr),
+    (xdr) => wallet.signTransaction(xdr)
   );
 
   console.log(`Stream created with ID: ${result.result}`);

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,62 +1,62 @@
 {
-    "name": "@fundable/sdk",
-    "version": "0.1.0",
-    "description": "TypeScript SDK for interacting with Fundable Stellar contracts",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.js"
-        }
-    },
-    "files": [
-        "dist",
-        "README.md",
-        "CHANGELOG.md"
-    ],
-    "scripts": {
-        "build": "tsc",
-        "dev": "tsc --watch",
-        "test": "vitest --run",
-        "test:watch": "vitest",
-        "lint": "eslint src --ext .ts,.tsx",
-        "format": "prettier --write \"src/**/*.{ts,tsx,json}\"",
-        "format:check": "prettier --check \"src/**/*.{ts,tsx,json}\""
-    },
-    "dependencies": {
-        "@stellar/stellar-sdk": "^14.4.3"
-    },
-    "devDependencies": {
-        "typescript": "^5",
-        "@types/node": "^20",
-        "vitest": "^2.0.0",
-        "eslint": "^8.57.0",
-        "@typescript-eslint/eslint-plugin": "^6.21.0",
-        "@typescript-eslint/parser": "^6.21.0",
-        "prettier": "^3.2.5"
-    },
-    "peerDependencies": {
-        "@stellar/stellar-sdk": "^14.4.3"
-    },
-    "keywords": [
-        "stellar",
-        "soroban",
-        "fundable",
-        "payment-streaming",
-        "defi",
-        "sdk"
-    ],
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Fundable-Protocol/stellar_client.git",
-        "directory": "packages/sdk"
-    },
-    "homepage": "https://github.com/Fundable-Protocol/stellar_client/tree/main/packages/sdk#readme",
-    "bugs": {
-        "url": "https://github.com/Fundable-Protocol/stellar_client/issues"
+  "name": "@fundable/sdk",
+  "version": "0.2.0",
+  "description": "TypeScript SDK for interacting with Fundable Stellar contracts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
     }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest --run",
+    "test:watch": "vitest",
+    "lint": "eslint src --ext .ts,.tsx",
+    "format": "prettier --write \"src/**/*.{ts,tsx,json}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,json}\""
+  },
+  "dependencies": {
+    "@stellar/stellar-sdk": "^14.4.3"
+  },
+  "devDependencies": {
+    "typescript": "^5",
+    "@types/node": "^20",
+    "vitest": "^2.0.0",
+    "eslint": "^8.57.0",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "prettier": "^3.2.5"
+  },
+  "peerDependencies": {
+    "@stellar/stellar-sdk": "^14.4.3"
+  },
+  "keywords": [
+    "stellar",
+    "soroban",
+    "fundable",
+    "payment-streaming",
+    "defi",
+    "sdk"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Fundable-Protocol/stellar_client.git",
+    "directory": "packages/sdk"
+  },
+  "homepage": "https://github.com/Fundable-Protocol/stellar_client/tree/main/packages/sdk#readme",
+  "bugs": {
+    "url": "https://github.com/Fundable-Protocol/stellar_client/issues"
+  }
 }

--- a/packages/sdk/src/DistributorClient.ts
+++ b/packages/sdk/src/DistributorClient.ts
@@ -2,6 +2,7 @@ import { Client as ContractClient } from "./generated/distributor/src/index";
 import {
   AssembledTransaction,
   ClientOptions as ContractClientOptions,
+  Address,
 } from "@stellar/stellar-sdk/contract";
 import {
   UserStats,
@@ -9,6 +10,18 @@ import {
   DistributionHistory,
 } from "./generated/distributor/src/index";
 import { executeWithErrorHandling } from "./utils/errors";
+
+/**
+ * Type alias for address parameters that accept both string and Address objects
+ */
+export type AddressParam = string | Address;
+
+/**
+ * Converts an AddressParam to its string representation
+ */
+function addressToString(address: AddressParam): string {
+  return typeof address === "string" ? address : address.toString();
+}
 
 /**
  * High-level client for interacting with the Distributor contract.
@@ -34,14 +47,20 @@ export class DistributorClient {
    * @throws {FundableStellarError} If distribution fails with a human-readable error message
    */
   public async distributeEqual(params: {
-    sender: string;
-    token: string;
+    sender: AddressParam;
+    token: AddressParam;
     total_amount: bigint;
-    recipients: string[];
+    recipients: AddressParam[];
   }): Promise<AssembledTransaction<null>> {
     return executeWithErrorHandling(
-      () => this.client.distribute_equal(params),
-      "Distribute tokens equally",
+      () =>
+        this.client.distribute_equal({
+          sender: addressToString(params.sender),
+          token: addressToString(params.token),
+          total_amount: params.total_amount,
+          recipients: params.recipients.map(addressToString),
+        }),
+      "Distribute tokens equally"
     );
   }
 
@@ -51,14 +70,20 @@ export class DistributorClient {
    * @throws {FundableStellarError} If distribution fails with a human-readable error message
    */
   public async distributeWeighted(params: {
-    sender: string;
-    token: string;
-    recipients: string[];
+    sender: AddressParam;
+    token: AddressParam;
+    recipients: AddressParam[];
     amounts: bigint[];
   }): Promise<AssembledTransaction<null>> {
     return executeWithErrorHandling(
-      () => this.client.distribute_weighted(params),
-      "Distribute tokens with weights",
+      () =>
+        this.client.distribute_weighted({
+          sender: addressToString(params.sender),
+          token: addressToString(params.token),
+          recipients: params.recipients.map(addressToString),
+          amounts: params.amounts,
+        }),
+      "Distribute tokens with weights"
     );
   }
 
@@ -69,7 +94,7 @@ export class DistributorClient {
   public async getAdmin(): Promise<AssembledTransaction<string | undefined>> {
     return executeWithErrorHandling(
       () => this.client.get_admin() as any,
-      "Get administrator",
+      "Get administrator"
     );
   }
 
@@ -79,11 +104,11 @@ export class DistributorClient {
    * @throws {FundableStellarError} If fetch fails with a human-readable error message
    */
   public async getUserStats(
-    user: string,
+    user: AddressParam
   ): Promise<AssembledTransaction<UserStats | undefined>> {
     return executeWithErrorHandling(
-      () => this.client.get_user_stats({ user }) as any,
-      "Get user statistics",
+      () => this.client.get_user_stats({ user: addressToString(user) }) as any,
+      "Get user statistics"
     );
   }
 
@@ -93,11 +118,12 @@ export class DistributorClient {
    * @throws {FundableStellarError} If fetch fails with a human-readable error message
    */
   public async getTokenStats(
-    token: string,
+    token: AddressParam
   ): Promise<AssembledTransaction<TokenStats | undefined>> {
     return executeWithErrorHandling(
-      () => this.client.get_token_stats({ token }) as any,
-      "Get token statistics",
+      () =>
+        this.client.get_token_stats({ token: addressToString(token) }) as any,
+      "Get token statistics"
     );
   }
 
@@ -108,7 +134,7 @@ export class DistributorClient {
   public async getTotalDistributions(): Promise<AssembledTransaction<bigint>> {
     return executeWithErrorHandling(
       () => this.client.get_total_distributions(),
-      "Get total distributions",
+      "Get total distributions"
     );
   }
 
@@ -121,7 +147,7 @@ export class DistributorClient {
   > {
     return executeWithErrorHandling(
       () => this.client.get_total_distributed_amount(),
-      "Get total distributed amount",
+      "Get total distributed amount"
     );
   }
 
@@ -133,11 +159,11 @@ export class DistributorClient {
    */
   public async getDistributionHistory(
     startId: bigint,
-    limit: bigint,
+    limit: bigint
   ): Promise<AssembledTransaction<DistributionHistory[]>> {
     return executeWithErrorHandling(
       () => this.client.get_distribution_history({ start_id: startId, limit }),
-      "Get distribution history",
+      "Get distribution history"
     );
   }
 
@@ -146,13 +172,18 @@ export class DistributorClient {
    * @throws {FundableStellarError} If initialization fails with a human-readable error message
    */
   public async initialize(params: {
-    admin: string;
+    admin: AddressParam;
     protocol_fee_percent: number;
-    fee_address: string;
+    fee_address: AddressParam;
   }): Promise<AssembledTransaction<null>> {
     return executeWithErrorHandling(
-      () => this.client.initialize(params),
-      "Initialize contract",
+      () =>
+        this.client.initialize({
+          admin: addressToString(params.admin),
+          protocol_fee_percent: params.protocol_fee_percent,
+          fee_address: addressToString(params.fee_address),
+        }),
+      "Initialize contract"
     );
   }
 
@@ -161,13 +192,16 @@ export class DistributorClient {
    * @throws {FundableStellarError} If operation fails with a human-readable error message
    */
   public async setProtocolFee(
-    admin: string,
-    newFeePercent: number,
+    admin: AddressParam,
+    newFeePercent: number
   ): Promise<AssembledTransaction<null>> {
     return executeWithErrorHandling(
       () =>
-        this.client.set_protocol_fee({ admin, new_fee_percent: newFeePercent }),
-      "Set protocol fee",
+        this.client.set_protocol_fee({
+          admin: addressToString(admin),
+          new_fee_percent: newFeePercent,
+        }),
+      "Set protocol fee"
     );
   }
 }

--- a/packages/sdk/src/PaymentStreamClient.ts
+++ b/packages/sdk/src/PaymentStreamClient.ts
@@ -2,6 +2,7 @@ import { Client as ContractClient } from "./generated/payment-stream/src/index";
 import {
   AssembledTransaction,
   ClientOptions as ContractClientOptions,
+  Address,
 } from "@stellar/stellar-sdk/contract";
 import {
   Stream,
@@ -10,8 +11,24 @@ import {
   StreamStatus,
 } from "./generated/payment-stream/src/index";
 import { executeWithErrorHandling } from "./utils/errors";
-import { getStreamHistory, getAllStreamHistory, StreamHistoryResult } from "./utils/streamHistory";
+import {
+  getStreamHistory,
+  getAllStreamHistory,
+  StreamHistoryResult,
+} from "./utils/streamHistory";
 import { PaymentStreamContractEvent } from "./utils/events";
+
+/**
+ * Type alias for address parameters that accept both string and Address objects
+ */
+export type AddressParam = string | Address;
+
+/**
+ * Converts an AddressParam to its string representation
+ */
+function addressToString(address: AddressParam): string {
+  return typeof address === "string" ? address : address.toString();
+}
 
 /**
  * High-level client for interacting with the Payment Stream contract.
@@ -43,17 +60,26 @@ export class PaymentStreamClient {
    * @throws {FundableStellarError} If stream creation fails with a human-readable error message
    */
   public async createStream(params: {
-    sender: string;
-    recipient: string;
-    token: string;
+    sender: AddressParam;
+    recipient: AddressParam;
+    token: AddressParam;
     total_amount: bigint;
     initial_amount: bigint;
     start_time: bigint;
     end_time: bigint;
   }): Promise<AssembledTransaction<bigint>> {
     return executeWithErrorHandling(
-      () => this.client.create_stream(params),
-      "Create stream",
+      () =>
+        this.client.create_stream({
+          sender: addressToString(params.sender),
+          recipient: addressToString(params.recipient),
+          token: addressToString(params.token),
+          total_amount: params.total_amount,
+          initial_amount: params.initial_amount,
+          start_time: params.start_time,
+          end_time: params.end_time,
+        }),
+      "Create stream"
     );
   }
 
@@ -65,11 +91,11 @@ export class PaymentStreamClient {
    */
   public async deposit(
     streamId: bigint,
-    amount: bigint,
+    amount: bigint
   ): Promise<AssembledTransaction<null>> {
     return executeWithErrorHandling(
       () => this.client.deposit({ stream_id: streamId, amount }),
-      "Deposit to stream",
+      "Deposit to stream"
     );
   }
 
@@ -81,11 +107,11 @@ export class PaymentStreamClient {
    */
   public async withdraw(
     streamId: bigint,
-    amount: bigint,
+    amount: bigint
   ): Promise<AssembledTransaction<null>> {
     return executeWithErrorHandling(
       () => this.client.withdraw({ stream_id: streamId, amount }),
-      "Withdraw from stream",
+      "Withdraw from stream"
     );
   }
 
@@ -95,11 +121,11 @@ export class PaymentStreamClient {
    * @throws {FundableStellarError} If withdrawal fails with a human-readable error message
    */
   public async withdrawMax(
-    streamId: bigint,
+    streamId: bigint
   ): Promise<AssembledTransaction<null>> {
     return executeWithErrorHandling(
       () => this.client.withdraw_max({ stream_id: streamId }),
-      "Withdraw maximum from stream",
+      "Withdraw maximum from stream"
     );
   }
 
@@ -109,11 +135,11 @@ export class PaymentStreamClient {
    * @throws {FundableStellarError} If pause fails with a human-readable error message
    */
   public async pauseStream(
-    streamId: bigint,
+    streamId: bigint
   ): Promise<AssembledTransaction<null>> {
     return executeWithErrorHandling(
       () => this.client.pause_stream({ stream_id: streamId }),
-      "Pause stream",
+      "Pause stream"
     );
   }
 
@@ -123,11 +149,11 @@ export class PaymentStreamClient {
    * @throws {FundableStellarError} If resume fails with a human-readable error message
    */
   public async resumeStream(
-    streamId: bigint,
+    streamId: bigint
   ): Promise<AssembledTransaction<null>> {
     return executeWithErrorHandling(
       () => this.client.resume_stream({ stream_id: streamId }),
-      "Resume stream",
+      "Resume stream"
     );
   }
 
@@ -137,11 +163,11 @@ export class PaymentStreamClient {
    * @throws {FundableStellarError} If cancellation fails with a human-readable error message
    */
   public async cancelStream(
-    streamId: bigint,
+    streamId: bigint
   ): Promise<AssembledTransaction<null>> {
     return executeWithErrorHandling(
       () => this.client.cancel_stream({ stream_id: streamId }),
-      "Cancel stream",
+      "Cancel stream"
     );
   }
 
@@ -151,11 +177,11 @@ export class PaymentStreamClient {
    * @throws {FundableStellarError} If fetch fails with a human-readable error message
    */
   public async getStream(
-    streamId: bigint,
+    streamId: bigint
   ): Promise<AssembledTransaction<Stream>> {
     return executeWithErrorHandling(
       () => this.client.get_stream({ stream_id: streamId }),
-      "Get stream details",
+      "Get stream details"
     );
   }
 
@@ -165,11 +191,11 @@ export class PaymentStreamClient {
    * @throws {FundableStellarError} If calculation fails with a human-readable error message
    */
   public async getWithdrawableAmount(
-    streamId: bigint,
+    streamId: bigint
   ): Promise<AssembledTransaction<bigint>> {
     return executeWithErrorHandling(
       () => this.client.withdrawable_amount({ stream_id: streamId }),
-      "Get withdrawable amount",
+      "Get withdrawable amount"
     );
   }
 
@@ -181,11 +207,15 @@ export class PaymentStreamClient {
    */
   public async setDelegate(
     streamId: bigint,
-    delegate: string,
+    delegate: AddressParam
   ): Promise<AssembledTransaction<null>> {
     return executeWithErrorHandling(
-      () => this.client.set_delegate({ stream_id: streamId, delegate }),
-      "Set delegate for stream",
+      () =>
+        this.client.set_delegate({
+          stream_id: streamId,
+          delegate: addressToString(delegate),
+        }),
+      "Set delegate for stream"
     );
   }
 
@@ -195,11 +225,11 @@ export class PaymentStreamClient {
    * @throws {FundableStellarError} If revocation fails with a human-readable error message
    */
   public async revokeDelegate(
-    streamId: bigint,
+    streamId: bigint
   ): Promise<AssembledTransaction<null>> {
     return executeWithErrorHandling(
       () => this.client.revoke_delegate({ stream_id: streamId }),
-      "Revoke stream delegate",
+      "Revoke stream delegate"
     );
   }
 
@@ -209,12 +239,12 @@ export class PaymentStreamClient {
    * @throws {FundableStellarError} If fetch fails with a human-readable error message
    */
   public async getDelegate(
-    streamId: bigint,
+    streamId: bigint
   ): Promise<AssembledTransaction<string | undefined>> {
     // Option<string> is usually returned as string | undefined or similar in the generated client
     return executeWithErrorHandling(
       () => this.client.get_delegate({ stream_id: streamId }) as any,
-      "Get stream delegate",
+      "Get stream delegate"
     );
   }
 
@@ -224,11 +254,11 @@ export class PaymentStreamClient {
    * @throws {FundableStellarError} If fetch fails with a human-readable error message
    */
   public async getStreamMetrics(
-    streamId: bigint,
+    streamId: bigint
   ): Promise<AssembledTransaction<StreamMetrics>> {
     return executeWithErrorHandling(
       () => this.client.get_stream_metrics({ stream_id: streamId }),
-      "Get stream metrics",
+      "Get stream metrics"
     );
   }
 
@@ -241,7 +271,7 @@ export class PaymentStreamClient {
   > {
     return executeWithErrorHandling(
       () => this.client.get_protocol_metrics(),
-      "Get protocol metrics",
+      "Get protocol metrics"
     );
   }
 
@@ -252,7 +282,7 @@ export class PaymentStreamClient {
   public async getFeeCollector(): Promise<AssembledTransaction<string>> {
     return executeWithErrorHandling(
       () => this.client.get_fee_collector(),
-      "Get fee collector",
+      "Get fee collector"
     );
   }
 
@@ -263,7 +293,7 @@ export class PaymentStreamClient {
   public async getProtocolFeeRate(): Promise<AssembledTransaction<number>> {
     return executeWithErrorHandling(
       () => this.client.get_protocol_fee_rate(),
-      "Get protocol fee rate",
+      "Get protocol fee rate"
     );
   }
 
@@ -272,13 +302,18 @@ export class PaymentStreamClient {
    * @throws {FundableStellarError} If initialization fails with a human-readable error message
    */
   public async initialize(params: {
-    admin: string;
-    fee_collector: string;
+    admin: AddressParam;
+    fee_collector: AddressParam;
     general_fee_rate: number;
   }): Promise<AssembledTransaction<null>> {
     return executeWithErrorHandling(
-      () => this.client.initialize(params),
-      "Initialize contract",
+      () =>
+        this.client.initialize({
+          admin: addressToString(params.admin),
+          fee_collector: addressToString(params.fee_collector),
+          general_fee_rate: params.general_fee_rate,
+        }),
+      "Initialize contract"
     );
   }
 

--- a/packages/sdk/src/__tests__/DistributorClient.test.ts
+++ b/packages/sdk/src/__tests__/DistributorClient.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { DistributorClient } from '../DistributorClient';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DistributorClient } from "../DistributorClient";
+import { Address } from "@stellar/stellar-sdk";
 
 // ---------------------------------------------------------------------------
 // Mock the generated distributor contract client
 // ---------------------------------------------------------------------------
-const mockTx = (result: unknown = undefined) => ({ result, signAndSend: vi.fn() });
+const mockTx = (result: unknown = undefined) => ({
+  result,
+  signAndSend: vi.fn(),
+});
 
 const mockContractClient = {
   distribute_equal: vi.fn(),
@@ -19,7 +23,7 @@ const mockContractClient = {
   set_protocol_fee: vi.fn(),
 };
 
-vi.mock('../generated/distributor/src/index', () => ({
+vi.mock("../generated/distributor/src/index", () => ({
   Client: vi.fn().mockImplementation(() => mockContractClient),
 }));
 
@@ -27,20 +31,20 @@ vi.mock('../generated/distributor/src/index', () => ({
 // Fixtures
 // ---------------------------------------------------------------------------
 const VALID_OPTIONS = {
-  contractId: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M',
-  networkPassphrase: 'Test SDF Network ; September 2015',
-  rpcUrl: 'https://soroban-testnet.stellar.org',
+  contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+  networkPassphrase: "Test SDF Network ; September 2015",
+  rpcUrl: "https://soroban-testnet.stellar.org",
 };
 
-const SENDER = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
-const TOKEN = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
-const RECIPIENT_A = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
-const RECIPIENT_B = 'GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+const SENDER = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const TOKEN = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM";
+const RECIPIENT_A = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const RECIPIENT_B = "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
-describe('DistributorClient', () => {
+describe("DistributorClient", () => {
   let client: DistributorClient;
 
   beforeEach(() => {
@@ -49,19 +53,19 @@ describe('DistributorClient', () => {
   });
 
   // ── constructor ────────────────────────────────────────────────────────────
-  describe('constructor', () => {
-    it('instantiates without throwing', () => {
+  describe("constructor", () => {
+    it("instantiates without throwing", () => {
       expect(client).toBeInstanceOf(DistributorClient);
     });
 
-    it('passes options through to the generated ContractClient', async () => {
-      const { Client } = await import('../generated/distributor/src/index');
+    it("passes options through to the generated ContractClient", async () => {
+      const { Client } = await import("../generated/distributor/src/index");
       expect(Client).toHaveBeenCalledWith(VALID_OPTIONS);
     });
   });
 
   // ── distributeEqual ────────────────────────────────────────────────────────
-  describe('distributeEqual', () => {
+  describe("distributeEqual", () => {
     const params = {
       sender: SENDER,
       token: TOKEN,
@@ -69,38 +73,72 @@ describe('DistributorClient', () => {
       recipients: [RECIPIENT_A, RECIPIENT_B],
     };
 
-    it('delegates to client.distribute_equal with correct params', async () => {
+    it("delegates to client.distribute_equal with correct params", async () => {
       mockContractClient.distribute_equal.mockResolvedValue(mockTx());
       await client.distributeEqual(params);
       expect(mockContractClient.distribute_equal).toHaveBeenCalledWith(params);
     });
 
-    it('returns AssembledTransaction<null>', async () => {
+    it("returns AssembledTransaction<null>", async () => {
       mockContractClient.distribute_equal.mockResolvedValue(mockTx(null));
       const tx = await client.distributeEqual(params);
       expect(tx.result).toBeNull();
     });
 
-    it('handles single recipient', async () => {
+    it("handles single recipient", async () => {
       mockContractClient.distribute_equal.mockResolvedValue(mockTx());
       const singleRecipient = { ...params, recipients: [RECIPIENT_A] };
       await client.distributeEqual(singleRecipient);
-      expect(mockContractClient.distribute_equal).toHaveBeenCalledWith(singleRecipient);
+      expect(mockContractClient.distribute_equal).toHaveBeenCalledWith(
+        singleRecipient
+      );
     });
 
-    it('propagates contract revert', async () => {
-      mockContractClient.distribute_equal.mockRejectedValue(new Error('InvalidAmount'));
-      await expect(client.distributeEqual(params)).rejects.toThrow('InvalidAmount');
+    it("propagates contract revert", async () => {
+      mockContractClient.distribute_equal.mockRejectedValue(
+        new Error("InvalidAmount")
+      );
+      await expect(client.distributeEqual(params)).rejects.toThrow(
+        "InvalidAmount"
+      );
     });
 
-    it('propagates network failure', async () => {
-      mockContractClient.distribute_equal.mockRejectedValue(new Error('Network error'));
-      await expect(client.distributeEqual(params)).rejects.toThrow('Network error');
+    it("propagates network failure", async () => {
+      mockContractClient.distribute_equal.mockRejectedValue(
+        new Error("Network error")
+      );
+      await expect(client.distributeEqual(params)).rejects.toThrow(
+        "Network error"
+      );
+    });
+
+    it("accepts Address objects for addresses", async () => {
+      mockContractClient.distribute_equal.mockResolvedValue(mockTx());
+      const addressParams = {
+        sender: new Address(SENDER),
+        token: new Address(TOKEN),
+        total_amount: 1000n,
+        recipients: [new Address(RECIPIENT_A), new Address(RECIPIENT_B)],
+      };
+      await client.distributeEqual(addressParams);
+      expect(mockContractClient.distribute_equal).toHaveBeenCalledWith(params);
+    });
+
+    it("accepts mixed string and Address objects", async () => {
+      mockContractClient.distribute_equal.mockResolvedValue(mockTx());
+      const mixedParams = {
+        sender: SENDER, // string
+        token: new Address(TOKEN), // Address
+        total_amount: 1000n,
+        recipients: [RECIPIENT_A, new Address(RECIPIENT_B)], // mixed
+      };
+      await client.distributeEqual(mixedParams);
+      expect(mockContractClient.distribute_equal).toHaveBeenCalledWith(params);
     });
   });
 
   // ── distributeWeighted ─────────────────────────────────────────────────────
-  describe('distributeWeighted', () => {
+  describe("distributeWeighted", () => {
     const params = {
       sender: SENDER,
       token: TOKEN,
@@ -108,46 +146,72 @@ describe('DistributorClient', () => {
       amounts: [700n, 300n],
     };
 
-    it('delegates to client.distribute_weighted with correct params', async () => {
+    it("delegates to client.distribute_weighted with correct params", async () => {
       mockContractClient.distribute_weighted.mockResolvedValue(mockTx());
       await client.distributeWeighted(params);
-      expect(mockContractClient.distribute_weighted).toHaveBeenCalledWith(params);
+      expect(mockContractClient.distribute_weighted).toHaveBeenCalledWith(
+        params
+      );
     });
 
-    it('returns AssembledTransaction<null>', async () => {
+    it("returns AssembledTransaction<null>", async () => {
       mockContractClient.distribute_weighted.mockResolvedValue(mockTx(null));
       const tx = await client.distributeWeighted(params);
       expect(tx.result).toBeNull();
     });
 
-    it('handles unequal weight distribution', async () => {
+    it("handles unequal weight distribution", async () => {
       const skewed = { ...params, amounts: [999n, 1n] };
       mockContractClient.distribute_weighted.mockResolvedValue(mockTx());
       await client.distributeWeighted(skewed);
-      expect(mockContractClient.distribute_weighted).toHaveBeenCalledWith(skewed);
+      expect(mockContractClient.distribute_weighted).toHaveBeenCalledWith(
+        skewed
+      );
     });
 
-    it('propagates mismatched recipients/amounts error', async () => {
-      mockContractClient.distribute_weighted.mockRejectedValue(new Error('InvalidAmount'));
+    it("propagates mismatched recipients/amounts error", async () => {
+      mockContractClient.distribute_weighted.mockRejectedValue(
+        new Error("InvalidAmount")
+      );
       const bad = { ...params, amounts: [100n] }; // length mismatch
-      await expect(client.distributeWeighted(bad)).rejects.toThrow('InvalidAmount');
+      await expect(client.distributeWeighted(bad)).rejects.toThrow(
+        "InvalidAmount"
+      );
     });
 
-    it('propagates Unauthorized error', async () => {
-      mockContractClient.distribute_weighted.mockRejectedValue(new Error('Unauthorized'));
-      await expect(client.distributeWeighted(params)).rejects.toThrow('Unauthorized');
+    it("propagates Unauthorized error", async () => {
+      mockContractClient.distribute_weighted.mockRejectedValue(
+        new Error("Unauthorized")
+      );
+      await expect(client.distributeWeighted(params)).rejects.toThrow(
+        "Unauthorized"
+      );
+    });
+
+    it("accepts Address objects for addresses", async () => {
+      mockContractClient.distribute_weighted.mockResolvedValue(mockTx());
+      const addressParams = {
+        sender: new Address(SENDER),
+        token: new Address(TOKEN),
+        recipients: [new Address(RECIPIENT_A), new Address(RECIPIENT_B)],
+        amounts: [700n, 300n],
+      };
+      await client.distributeWeighted(addressParams);
+      expect(mockContractClient.distribute_weighted).toHaveBeenCalledWith(
+        params
+      );
     });
   });
 
   // ── getAdmin ───────────────────────────────────────────────────────────────
-  describe('getAdmin', () => {
-    it('returns admin address when set', async () => {
+  describe("getAdmin", () => {
+    it("returns admin address when set", async () => {
       mockContractClient.get_admin.mockResolvedValue(mockTx(SENDER));
       const tx = await client.getAdmin();
       expect(tx.result).toBe(SENDER);
     });
 
-    it('returns undefined when no admin is set', async () => {
+    it("returns undefined when no admin is set", async () => {
       mockContractClient.get_admin.mockResolvedValue(mockTxNone());
       const tx = await client.getAdmin();
       expect(tx.result).toBeUndefined();
@@ -155,73 +219,92 @@ describe('DistributorClient', () => {
   });
 
   // ── getUserStats ───────────────────────────────────────────────────────────
-  describe('getUserStats', () => {
+  describe("getUserStats", () => {
     const mockStats = {
       distributions_initiated: 3,
       total_amount: 5000n,
     };
 
-    it('delegates to client.get_user_stats with correct user param', async () => {
+    it("delegates to client.get_user_stats with correct user param", async () => {
       mockContractClient.get_user_stats.mockResolvedValue(mockTx(mockStats));
       const tx = await client.getUserStats(SENDER);
-      expect(mockContractClient.get_user_stats).toHaveBeenCalledWith({ user: SENDER });
+      expect(mockContractClient.get_user_stats).toHaveBeenCalledWith({
+        user: SENDER,
+      });
       expect(tx.result).toEqual(mockStats);
     });
 
-    it('returns correct UserStats shape', async () => {
+    it("returns correct UserStats shape", async () => {
       mockContractClient.get_user_stats.mockResolvedValue(mockTx(mockStats));
       const tx = await client.getUserStats(SENDER);
-      expect(tx.result).toHaveProperty('distributions_initiated');
-      expect(tx.result).toHaveProperty('total_amount');
+      expect(tx.result).toHaveProperty("distributions_initiated");
+      expect(tx.result).toHaveProperty("total_amount");
     });
 
-    it('returns undefined for unknown user', async () => {
+    it("returns undefined for unknown user", async () => {
       mockContractClient.get_user_stats.mockResolvedValue(mockTxNone());
-      const tx = await client.getUserStats('GUNKNOWN');
+      const tx = await client.getUserStats("GUNKNOWN");
       expect(tx.result).toBeUndefined();
+    });
+    it("accepts Address object for user param", async () => {
+      mockContractClient.get_user_stats.mockResolvedValue(mockTx(mockStats));
+      const tx = await client.getUserStats(new Address(SENDER));
+      expect(mockContractClient.get_user_stats).toHaveBeenCalledWith({
+        user: SENDER,
+      });
     });
   });
 
   // ── getTokenStats ──────────────────────────────────────────────────────────
-  describe('getTokenStats', () => {
+  describe("getTokenStats", () => {
     const mockStats = {
       distribution_count: 5,
       last_time: 1700000000n,
       total_amount: 25000n,
     };
 
-    it('delegates to client.get_token_stats with correct token param', async () => {
+    it("delegates to client.get_token_stats with correct token param", async () => {
       mockContractClient.get_token_stats.mockResolvedValue(mockTx(mockStats));
       const tx = await client.getTokenStats(TOKEN);
-      expect(mockContractClient.get_token_stats).toHaveBeenCalledWith({ token: TOKEN });
+      expect(mockContractClient.get_token_stats).toHaveBeenCalledWith({
+        token: TOKEN,
+      });
       expect(tx.result).toEqual(mockStats);
     });
 
-    it('returns correct TokenStats shape', async () => {
+    it("returns correct TokenStats shape", async () => {
       mockContractClient.get_token_stats.mockResolvedValue(mockTx(mockStats));
       const tx = await client.getTokenStats(TOKEN);
-      expect(tx.result).toHaveProperty('distribution_count');
-      expect(tx.result).toHaveProperty('last_time');
-      expect(tx.result).toHaveProperty('total_amount');
+      expect(tx.result).toHaveProperty("distribution_count");
+      expect(tx.result).toHaveProperty("last_time");
+      expect(tx.result).toHaveProperty("total_amount");
     });
 
-    it('returns undefined for unknown token', async () => {
+    it("returns undefined for unknown token", async () => {
       mockContractClient.get_token_stats.mockResolvedValue(mockTxNone());
-      const tx = await client.getTokenStats('CUNKNOWN');
+      const tx = await client.getTokenStats("CUNKNOWN");
       expect(tx.result).toBeUndefined();
+    });
+
+    it("accepts Address object for token param", async () => {
+      mockContractClient.get_token_stats.mockResolvedValue(mockTx(mockStats));
+      const tx = await client.getTokenStats(new Address(TOKEN));
+      expect(mockContractClient.get_token_stats).toHaveBeenCalledWith({
+        token: TOKEN,
+      });
     });
   });
 
   // ── getTotalDistributions ──────────────────────────────────────────────────
-  describe('getTotalDistributions', () => {
-    it('returns total distribution count as bigint', async () => {
+  describe("getTotalDistributions", () => {
+    it("returns total distribution count as bigint", async () => {
       mockContractClient.get_total_distributions.mockResolvedValue(mockTx(42n));
       const tx = await client.getTotalDistributions();
       expect(mockContractClient.get_total_distributions).toHaveBeenCalled();
       expect(tx.result).toBe(42n);
     });
 
-    it('returns 0n when no distributions have occurred', async () => {
+    it("returns 0n when no distributions have occurred", async () => {
       mockContractClient.get_total_distributions.mockResolvedValue(mockTx(0n));
       const tx = await client.getTotalDistributions();
       expect(tx.result).toBe(0n);
@@ -229,17 +312,21 @@ describe('DistributorClient', () => {
   });
 
   // ── getTotalDistributedAmount ──────────────────────────────────────────────
-  describe('getTotalDistributedAmount', () => {
-    it('returns total distributed amount as bigint', async () => {
-      mockContractClient.get_total_distributed_amount.mockResolvedValue(mockTx(100000n));
+  describe("getTotalDistributedAmount", () => {
+    it("returns total distributed amount as bigint", async () => {
+      mockContractClient.get_total_distributed_amount.mockResolvedValue(
+        mockTx(100000n)
+      );
       const tx = await client.getTotalDistributedAmount();
-      expect(mockContractClient.get_total_distributed_amount).toHaveBeenCalled();
+      expect(
+        mockContractClient.get_total_distributed_amount
+      ).toHaveBeenCalled();
       expect(tx.result).toBe(100000n);
     });
   });
 
   // ── getDistributionHistory ─────────────────────────────────────────────────
-  describe('getDistributionHistory', () => {
+  describe("getDistributionHistory", () => {
     const mockHistory = [
       {
         amount: 1000n,
@@ -250,8 +337,10 @@ describe('DistributorClient', () => {
       },
     ];
 
-    it('delegates to client.get_distribution_history with correct params', async () => {
-      mockContractClient.get_distribution_history.mockResolvedValue(mockTx(mockHistory));
+    it("delegates to client.get_distribution_history with correct params", async () => {
+      mockContractClient.get_distribution_history.mockResolvedValue(
+        mockTx(mockHistory)
+      );
       const tx = await client.getDistributionHistory(0n, 10n);
       expect(mockContractClient.get_distribution_history).toHaveBeenCalledWith({
         start_id: 0n,
@@ -260,24 +349,26 @@ describe('DistributorClient', () => {
       expect(tx.result).toEqual(mockHistory);
     });
 
-    it('returns empty array when no history exists', async () => {
+    it("returns empty array when no history exists", async () => {
       mockContractClient.get_distribution_history.mockResolvedValue(mockTx([]));
       const tx = await client.getDistributionHistory(0n, 10n);
       expect(tx.result).toEqual([]);
     });
 
-    it('returns correct DistributionHistory shape', async () => {
-      mockContractClient.get_distribution_history.mockResolvedValue(mockTx(mockHistory));
+    it("returns correct DistributionHistory shape", async () => {
+      mockContractClient.get_distribution_history.mockResolvedValue(
+        mockTx(mockHistory)
+      );
       const tx = await client.getDistributionHistory(0n, 1n);
       const entry = (tx.result as typeof mockHistory)[0];
-      expect(entry).toHaveProperty('amount');
-      expect(entry).toHaveProperty('recipients_count');
-      expect(entry).toHaveProperty('sender');
-      expect(entry).toHaveProperty('timestamp');
-      expect(entry).toHaveProperty('token');
+      expect(entry).toHaveProperty("amount");
+      expect(entry).toHaveProperty("recipients_count");
+      expect(entry).toHaveProperty("sender");
+      expect(entry).toHaveProperty("timestamp");
+      expect(entry).toHaveProperty("token");
     });
 
-    it('respects pagination params', async () => {
+    it("respects pagination params", async () => {
       mockContractClient.get_distribution_history.mockResolvedValue(mockTx([]));
       await client.getDistributionHistory(5n, 20n);
       expect(mockContractClient.get_distribution_history).toHaveBeenCalledWith({
@@ -288,28 +379,43 @@ describe('DistributorClient', () => {
   });
 
   // ── initialize ─────────────────────────────────────────────────────────────
-  describe('initialize', () => {
+  describe("initialize", () => {
     const params = {
       admin: SENDER,
       protocol_fee_percent: 5,
       fee_address: RECIPIENT_A,
     };
 
-    it('delegates to client.initialize with correct params', async () => {
+    it("delegates to client.initialize with correct params", async () => {
       mockContractClient.initialize.mockResolvedValue(mockTx());
       await client.initialize(params);
       expect(mockContractClient.initialize).toHaveBeenCalledWith(params);
     });
 
-    it('propagates AlreadyInitialized error', async () => {
-      mockContractClient.initialize.mockRejectedValue(new Error('AlreadyInitialized'));
-      await expect(client.initialize(params)).rejects.toThrow('AlreadyInitialized');
+    it("propagates AlreadyInitialized error", async () => {
+      mockContractClient.initialize.mockRejectedValue(
+        new Error("AlreadyInitialized")
+      );
+      await expect(client.initialize(params)).rejects.toThrow(
+        "AlreadyInitialized"
+      );
+    });
+
+    it("accepts Address objects for addresses", async () => {
+      mockContractClient.initialize.mockResolvedValue(mockTx());
+      const addressParams = {
+        admin: new Address(SENDER),
+        protocol_fee_percent: 5,
+        fee_address: new Address(RECIPIENT_A),
+      };
+      await client.initialize(addressParams);
+      expect(mockContractClient.initialize).toHaveBeenCalledWith(params);
     });
   });
 
   // ── setProtocolFee ─────────────────────────────────────────────────────────
-  describe('setProtocolFee', () => {
-    it('delegates to client.set_protocol_fee with correct params', async () => {
+  describe("setProtocolFee", () => {
+    it("delegates to client.set_protocol_fee with correct params", async () => {
       mockContractClient.set_protocol_fee.mockResolvedValue(mockTx());
       await client.setProtocolFee(SENDER, 10);
       expect(mockContractClient.set_protocol_fee).toHaveBeenCalledWith({
@@ -318,14 +424,31 @@ describe('DistributorClient', () => {
       });
     });
 
-    it('propagates Unauthorized error when non-admin calls', async () => {
-      mockContractClient.set_protocol_fee.mockRejectedValue(new Error('Unauthorized'));
-      await expect(client.setProtocolFee('GNOTADMIN', 10)).rejects.toThrow('Unauthorized');
+    it("propagates Unauthorized error when non-admin calls", async () => {
+      mockContractClient.set_protocol_fee.mockRejectedValue(
+        new Error("Unauthorized")
+      );
+      await expect(client.setProtocolFee("GNOTADMIN", 10)).rejects.toThrow(
+        "Unauthorized"
+      );
     });
 
-    it('propagates FeeTooHigh error', async () => {
-      mockContractClient.set_protocol_fee.mockRejectedValue(new Error('FeeTooHigh'));
-      await expect(client.setProtocolFee(SENDER, 9999)).rejects.toThrow('FeeTooHigh');
+    it("propagates FeeTooHigh error", async () => {
+      mockContractClient.set_protocol_fee.mockRejectedValue(
+        new Error("FeeTooHigh")
+      );
+      await expect(client.setProtocolFee(SENDER, 9999)).rejects.toThrow(
+        "FeeTooHigh"
+      );
+    });
+
+    it("accepts Address object for admin param", async () => {
+      mockContractClient.set_protocol_fee.mockResolvedValue(mockTx());
+      await client.setProtocolFee(new Address(SENDER), 10);
+      expect(mockContractClient.set_protocol_fee).toHaveBeenCalledWith({
+        admin: SENDER,
+        new_fee_percent: 10,
+      });
     });
   });
 });

--- a/packages/sdk/src/__tests__/PaymentStreamClient.test.ts
+++ b/packages/sdk/src/__tests__/PaymentStreamClient.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { PaymentStreamClient } from '../PaymentStreamClient';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PaymentStreamClient } from "../PaymentStreamClient";
+import { Address } from "@stellar/stellar-sdk";
 
 // ---------------------------------------------------------------------------
 // Mock the generated contract client at the module level so no RPC calls
@@ -7,7 +8,10 @@ import { PaymentStreamClient } from '../PaymentStreamClient';
 // AssembledTransaction-shaped object.
 // ---------------------------------------------------------------------------
 const mockSignAndSend = vi.fn();
-const mockTx = (result: unknown = undefined) => ({ result, signAndSend: mockSignAndSend });
+const mockTx = (result: unknown = undefined) => ({
+  result,
+  signAndSend: mockSignAndSend,
+});
 
 const mockContractClient = {
   create_stream: vi.fn(),
@@ -29,7 +33,7 @@ const mockContractClient = {
   initialize: vi.fn(),
 };
 
-vi.mock('../generated/payment-stream/src/index', () => ({
+vi.mock("../generated/payment-stream/src/index", () => ({
   Client: vi.fn().mockImplementation(() => mockContractClient),
 }));
 
@@ -37,21 +41,21 @@ vi.mock('../generated/payment-stream/src/index', () => ({
 // Fixtures
 // ---------------------------------------------------------------------------
 const VALID_OPTIONS = {
-  contractId: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM',
-  networkPassphrase: 'Test SDF Network ; September 2015',
-  rpcUrl: 'https://soroban-testnet.stellar.org',
+  contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+  networkPassphrase: "Test SDF Network ; September 2015",
+  rpcUrl: "https://soroban-testnet.stellar.org",
 };
 
-const SENDER = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
-const RECIPIENT = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
-const TOKEN = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
-const DELEGATE = 'GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+const SENDER = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const RECIPIENT = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const TOKEN = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM";
+const DELEGATE = "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
 const STREAM_ID = 1n;
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
-describe('PaymentStreamClient', () => {
+describe("PaymentStreamClient", () => {
   let client: PaymentStreamClient;
 
   beforeEach(() => {
@@ -60,19 +64,19 @@ describe('PaymentStreamClient', () => {
   });
 
   // ── constructor ────────────────────────────────────────────────────────────
-  describe('constructor', () => {
-    it('instantiates without throwing', () => {
+  describe("constructor", () => {
+    it("instantiates without throwing", () => {
       expect(client).toBeInstanceOf(PaymentStreamClient);
     });
 
-    it('passes options through to the generated ContractClient', async () => {
-      const { Client } = await import('../generated/payment-stream/src/index');
+    it("passes options through to the generated ContractClient", async () => {
+      const { Client } = await import("../generated/payment-stream/src/index");
       expect(Client).toHaveBeenCalledWith(VALID_OPTIONS);
     });
   });
 
   // ── createStream ───────────────────────────────────────────────────────────
-  describe('createStream', () => {
+  describe("createStream", () => {
     const params = {
       sender: SENDER,
       recipient: RECIPIENT,
@@ -83,122 +87,183 @@ describe('PaymentStreamClient', () => {
       end_time: 2000n,
     };
 
-    it('delegates to client.create_stream with correct params', async () => {
+    it("delegates to client.create_stream with correct params", async () => {
       mockContractClient.create_stream.mockResolvedValue(mockTx(1n));
       const tx = await client.createStream(params);
       expect(mockContractClient.create_stream).toHaveBeenCalledWith(params);
       expect(tx.result).toBe(1n);
     });
 
-    it('returns an AssembledTransaction with bigint result', async () => {
+    it("returns an AssembledTransaction with bigint result", async () => {
       mockContractClient.create_stream.mockResolvedValue(mockTx(42n));
       const tx = await client.createStream(params);
       expect(tx.result).toBe(42n);
     });
 
-    it('propagates contract errors', async () => {
-      mockContractClient.create_stream.mockRejectedValue(new Error('InvalidTimeRange'));
-      await expect(client.createStream(params)).rejects.toThrow('InvalidTimeRange');
+    it("propagates contract errors", async () => {
+      mockContractClient.create_stream.mockRejectedValue(
+        new Error("InvalidTimeRange")
+      );
+      await expect(client.createStream(params)).rejects.toThrow(
+        "InvalidTimeRange"
+      );
     });
 
-    it('propagates network failures', async () => {
-      mockContractClient.create_stream.mockRejectedValue(new Error('Network error'));
-      await expect(client.createStream(params)).rejects.toThrow('Network error');
+    it("propagates network failures", async () => {
+      mockContractClient.create_stream.mockRejectedValue(
+        new Error("Network error")
+      );
+      await expect(client.createStream(params)).rejects.toThrow(
+        "Network error"
+      );
+    });
+
+    it("accepts Address objects for addresses", async () => {
+      mockContractClient.create_stream.mockResolvedValue(mockTx(1n));
+      const addressParams = {
+        sender: new Address(SENDER),
+        recipient: new Address(RECIPIENT),
+        token: new Address(TOKEN),
+        total_amount: 1000n,
+        initial_amount: 0n,
+        start_time: 1000n,
+        end_time: 2000n,
+      };
+      const tx = await client.createStream(addressParams);
+      expect(mockContractClient.create_stream).toHaveBeenCalledWith(params);
     });
   });
 
   // ── deposit ────────────────────────────────────────────────────────────────
-  describe('deposit', () => {
-    it('delegates to client.deposit with correct params', async () => {
+  describe("deposit", () => {
+    it("delegates to client.deposit with correct params", async () => {
       mockContractClient.deposit.mockResolvedValue(mockTx());
       await client.deposit(STREAM_ID, 500n);
-      expect(mockContractClient.deposit).toHaveBeenCalledWith({ stream_id: STREAM_ID, amount: 500n });
+      expect(mockContractClient.deposit).toHaveBeenCalledWith({
+        stream_id: STREAM_ID,
+        amount: 500n,
+      });
     });
 
-    it('returns AssembledTransaction<null>', async () => {
+    it("returns AssembledTransaction<null>", async () => {
       mockContractClient.deposit.mockResolvedValue(mockTx(null));
       const tx = await client.deposit(STREAM_ID, 500n);
       expect(tx.result).toBeNull();
     });
 
-    it('propagates contract revert on DepositExceedsTotal', async () => {
-      mockContractClient.deposit.mockRejectedValue(new Error('DepositExceedsTotal'));
-      await expect(client.deposit(STREAM_ID, 999999n)).rejects.toThrow('DepositExceedsTotal');
+    it("propagates contract revert on DepositExceedsTotal", async () => {
+      mockContractClient.deposit.mockRejectedValue(
+        new Error("DepositExceedsTotal")
+      );
+      await expect(client.deposit(STREAM_ID, 999999n)).rejects.toThrow(
+        "DepositExceedsTotal"
+      );
     });
   });
 
   // ── withdraw ───────────────────────────────────────────────────────────────
-  describe('withdraw', () => {
-    it('delegates to client.withdraw with correct params', async () => {
+  describe("withdraw", () => {
+    it("delegates to client.withdraw with correct params", async () => {
       mockContractClient.withdraw.mockResolvedValue(mockTx());
       await client.withdraw(STREAM_ID, 100n);
-      expect(mockContractClient.withdraw).toHaveBeenCalledWith({ stream_id: STREAM_ID, amount: 100n });
+      expect(mockContractClient.withdraw).toHaveBeenCalledWith({
+        stream_id: STREAM_ID,
+        amount: 100n,
+      });
     });
 
-    it('propagates InsufficientWithdrawable error', async () => {
-      mockContractClient.withdraw.mockRejectedValue(new Error('InsufficientWithdrawable'));
-      await expect(client.withdraw(STREAM_ID, 9999n)).rejects.toThrow('InsufficientWithdrawable');
+    it("propagates InsufficientWithdrawable error", async () => {
+      mockContractClient.withdraw.mockRejectedValue(
+        new Error("InsufficientWithdrawable")
+      );
+      await expect(client.withdraw(STREAM_ID, 9999n)).rejects.toThrow(
+        "InsufficientWithdrawable"
+      );
     });
   });
 
   // ── withdrawMax ────────────────────────────────────────────────────────────
-  describe('withdrawMax', () => {
-    it('delegates to client.withdraw_max', async () => {
+  describe("withdrawMax", () => {
+    it("delegates to client.withdraw_max", async () => {
       mockContractClient.withdraw_max.mockResolvedValue(mockTx());
       await client.withdrawMax(STREAM_ID);
-      expect(mockContractClient.withdraw_max).toHaveBeenCalledWith({ stream_id: STREAM_ID });
+      expect(mockContractClient.withdraw_max).toHaveBeenCalledWith({
+        stream_id: STREAM_ID,
+      });
     });
   });
 
   // ── pauseStream ────────────────────────────────────────────────────────────
-  describe('pauseStream', () => {
-    it('delegates to client.pause_stream', async () => {
+  describe("pauseStream", () => {
+    it("delegates to client.pause_stream", async () => {
       mockContractClient.pause_stream.mockResolvedValue(mockTx());
       await client.pauseStream(STREAM_ID);
-      expect(mockContractClient.pause_stream).toHaveBeenCalledWith({ stream_id: STREAM_ID });
+      expect(mockContractClient.pause_stream).toHaveBeenCalledWith({
+        stream_id: STREAM_ID,
+      });
     });
 
-    it('propagates Unauthorized error', async () => {
-      mockContractClient.pause_stream.mockRejectedValue(new Error('Unauthorized'));
-      await expect(client.pauseStream(STREAM_ID)).rejects.toThrow('Unauthorized');
+    it("propagates Unauthorized error", async () => {
+      mockContractClient.pause_stream.mockRejectedValue(
+        new Error("Unauthorized")
+      );
+      await expect(client.pauseStream(STREAM_ID)).rejects.toThrow(
+        "Unauthorized"
+      );
     });
 
-    it('propagates StreamNotActive error', async () => {
-      mockContractClient.pause_stream.mockRejectedValue(new Error('StreamNotActive'));
-      await expect(client.pauseStream(STREAM_ID)).rejects.toThrow('StreamNotActive');
+    it("propagates StreamNotActive error", async () => {
+      mockContractClient.pause_stream.mockRejectedValue(
+        new Error("StreamNotActive")
+      );
+      await expect(client.pauseStream(STREAM_ID)).rejects.toThrow(
+        "StreamNotActive"
+      );
     });
   });
 
   // ── resumeStream ───────────────────────────────────────────────────────────
-  describe('resumeStream', () => {
-    it('delegates to client.resume_stream', async () => {
+  describe("resumeStream", () => {
+    it("delegates to client.resume_stream", async () => {
       mockContractClient.resume_stream.mockResolvedValue(mockTx());
       await client.resumeStream(STREAM_ID);
-      expect(mockContractClient.resume_stream).toHaveBeenCalledWith({ stream_id: STREAM_ID });
+      expect(mockContractClient.resume_stream).toHaveBeenCalledWith({
+        stream_id: STREAM_ID,
+      });
     });
 
-    it('propagates StreamNotPaused error', async () => {
-      mockContractClient.resume_stream.mockRejectedValue(new Error('StreamNotPaused'));
-      await expect(client.resumeStream(STREAM_ID)).rejects.toThrow('StreamNotPaused');
+    it("propagates StreamNotPaused error", async () => {
+      mockContractClient.resume_stream.mockRejectedValue(
+        new Error("StreamNotPaused")
+      );
+      await expect(client.resumeStream(STREAM_ID)).rejects.toThrow(
+        "StreamNotPaused"
+      );
     });
   });
 
   // ── cancelStream ───────────────────────────────────────────────────────────
-  describe('cancelStream', () => {
-    it('delegates to client.cancel_stream', async () => {
+  describe("cancelStream", () => {
+    it("delegates to client.cancel_stream", async () => {
       mockContractClient.cancel_stream.mockResolvedValue(mockTx());
       await client.cancelStream(STREAM_ID);
-      expect(mockContractClient.cancel_stream).toHaveBeenCalledWith({ stream_id: STREAM_ID });
+      expect(mockContractClient.cancel_stream).toHaveBeenCalledWith({
+        stream_id: STREAM_ID,
+      });
     });
 
-    it('propagates StreamCannotBeCanceled error', async () => {
-      mockContractClient.cancel_stream.mockRejectedValue(new Error('StreamCannotBeCanceled'));
-      await expect(client.cancelStream(STREAM_ID)).rejects.toThrow('StreamCannotBeCanceled');
+    it("propagates StreamCannotBeCanceled error", async () => {
+      mockContractClient.cancel_stream.mockRejectedValue(
+        new Error("StreamCannotBeCanceled")
+      );
+      await expect(client.cancelStream(STREAM_ID)).rejects.toThrow(
+        "StreamCannotBeCanceled"
+      );
     });
   });
 
   // ── getStream ──────────────────────────────────────────────────────────────
-  describe('getStream', () => {
+  describe("getStream", () => {
     const mockStream = {
       id: STREAM_ID,
       sender: SENDER,
@@ -209,48 +274,54 @@ describe('PaymentStreamClient', () => {
       withdrawn_amount: 0n,
       start_time: 1000n,
       end_time: 2000n,
-      status: { tag: 'Active', values: undefined },
+      status: { tag: "Active", values: undefined },
       paused_at: undefined,
       total_paused_duration: 0n,
     };
 
-    it('delegates to client.get_stream', async () => {
+    it("delegates to client.get_stream", async () => {
       mockContractClient.get_stream.mockResolvedValue(mockTx(mockStream));
       const tx = await client.getStream(STREAM_ID);
-      expect(mockContractClient.get_stream).toHaveBeenCalledWith({ stream_id: STREAM_ID });
+      expect(mockContractClient.get_stream).toHaveBeenCalledWith({
+        stream_id: STREAM_ID,
+      });
       expect(tx.result).toEqual(mockStream);
     });
 
-    it('returns correct Stream shape', async () => {
+    it("returns correct Stream shape", async () => {
       mockContractClient.get_stream.mockResolvedValue(mockTx(mockStream));
       const tx = await client.getStream(STREAM_ID);
       const stream = tx.result;
-      expect(stream).toHaveProperty('id');
-      expect(stream).toHaveProperty('sender');
-      expect(stream).toHaveProperty('recipient');
-      expect(stream).toHaveProperty('token');
-      expect(stream).toHaveProperty('status');
+      expect(stream).toHaveProperty("id");
+      expect(stream).toHaveProperty("sender");
+      expect(stream).toHaveProperty("recipient");
+      expect(stream).toHaveProperty("token");
+      expect(stream).toHaveProperty("status");
     });
 
-    it('propagates StreamNotFound error', async () => {
-      mockContractClient.get_stream.mockRejectedValue(new Error('StreamNotFound'));
-      await expect(client.getStream(999n)).rejects.toThrow('StreamNotFound');
+    it("propagates StreamNotFound error", async () => {
+      mockContractClient.get_stream.mockRejectedValue(
+        new Error("StreamNotFound")
+      );
+      await expect(client.getStream(999n)).rejects.toThrow("StreamNotFound");
     });
   });
 
   // ── getWithdrawableAmount ──────────────────────────────────────────────────
-  describe('getWithdrawableAmount', () => {
-    it('delegates to client.withdrawable_amount', async () => {
+  describe("getWithdrawableAmount", () => {
+    it("delegates to client.withdrawable_amount", async () => {
       mockContractClient.withdrawable_amount.mockResolvedValue(mockTx(250n));
       const tx = await client.getWithdrawableAmount(STREAM_ID);
-      expect(mockContractClient.withdrawable_amount).toHaveBeenCalledWith({ stream_id: STREAM_ID });
+      expect(mockContractClient.withdrawable_amount).toHaveBeenCalledWith({
+        stream_id: STREAM_ID,
+      });
       expect(tx.result).toBe(250n);
     });
   });
 
   // ── setDelegate ────────────────────────────────────────────────────────────
-  describe('setDelegate', () => {
-    it('delegates to client.set_delegate with correct params', async () => {
+  describe("setDelegate", () => {
+    it("delegates to client.set_delegate with correct params", async () => {
       mockContractClient.set_delegate.mockResolvedValue(mockTx());
       await client.setDelegate(STREAM_ID, DELEGATE);
       expect(mockContractClient.set_delegate).toHaveBeenCalledWith({
@@ -259,35 +330,54 @@ describe('PaymentStreamClient', () => {
       });
     });
 
-    it('propagates InvalidDelegate error', async () => {
-      mockContractClient.set_delegate.mockRejectedValue(new Error('InvalidDelegate'));
-      await expect(client.setDelegate(STREAM_ID, 'bad')).rejects.toThrow('InvalidDelegate');
+    it("propagates InvalidDelegate error", async () => {
+      mockContractClient.set_delegate.mockRejectedValue(
+        new Error("InvalidDelegate")
+      );
+      await expect(client.setDelegate(STREAM_ID, "bad")).rejects.toThrow(
+        "InvalidDelegate"
+      );
+    });
+
+    it("accepts Address object for delegate param", async () => {
+      mockContractClient.set_delegate.mockResolvedValue(mockTx());
+      await client.setDelegate(STREAM_ID, new Address(DELEGATE));
+      expect(mockContractClient.set_delegate).toHaveBeenCalledWith({
+        stream_id: STREAM_ID,
+        delegate: DELEGATE,
+      });
     });
   });
 
   // ── revokeDelegate ─────────────────────────────────────────────────────────
-  describe('revokeDelegate', () => {
-    it('delegates to client.revoke_delegate', async () => {
+  describe("revokeDelegate", () => {
+    it("delegates to client.revoke_delegate", async () => {
       mockContractClient.revoke_delegate.mockResolvedValue(mockTx());
       await client.revokeDelegate(STREAM_ID);
-      expect(mockContractClient.revoke_delegate).toHaveBeenCalledWith({ stream_id: STREAM_ID });
+      expect(mockContractClient.revoke_delegate).toHaveBeenCalledWith({
+        stream_id: STREAM_ID,
+      });
     });
 
-    it('propagates Unauthorized error', async () => {
-      mockContractClient.revoke_delegate.mockRejectedValue(new Error('Unauthorized'));
-      await expect(client.revokeDelegate(STREAM_ID)).rejects.toThrow('Unauthorized');
+    it("propagates Unauthorized error", async () => {
+      mockContractClient.revoke_delegate.mockRejectedValue(
+        new Error("Unauthorized")
+      );
+      await expect(client.revokeDelegate(STREAM_ID)).rejects.toThrow(
+        "Unauthorized"
+      );
     });
   });
 
   // ── getDelegate ────────────────────────────────────────────────────────────
-  describe('getDelegate', () => {
-    it('returns delegate address when set', async () => {
+  describe("getDelegate", () => {
+    it("returns delegate address when set", async () => {
       mockContractClient.get_delegate.mockResolvedValue(mockTx(DELEGATE));
       const tx = await client.getDelegate(STREAM_ID);
       expect(tx.result).toBe(DELEGATE);
     });
 
-    it('returns undefined when no delegate is set', async () => {
+    it("returns undefined when no delegate is set", async () => {
       mockContractClient.get_delegate.mockResolvedValue(mockTxNone());
       const tx = await client.getDelegate(STREAM_ID);
       expect(tx.result).toBeUndefined();
@@ -295,7 +385,7 @@ describe('PaymentStreamClient', () => {
   });
 
   // ── getStreamMetrics ───────────────────────────────────────────────────────
-  describe('getStreamMetrics', () => {
+  describe("getStreamMetrics", () => {
     const mockMetrics = {
       current_delegate: undefined,
       last_activity: 1000n,
@@ -306,32 +396,40 @@ describe('PaymentStreamClient', () => {
       withdrawal_count: 0,
     };
 
-    it('delegates to client.get_stream_metrics', async () => {
-      mockContractClient.get_stream_metrics.mockResolvedValue(mockTx(mockMetrics));
+    it("delegates to client.get_stream_metrics", async () => {
+      mockContractClient.get_stream_metrics.mockResolvedValue(
+        mockTx(mockMetrics)
+      );
       const tx = await client.getStreamMetrics(STREAM_ID);
-      expect(mockContractClient.get_stream_metrics).toHaveBeenCalledWith({ stream_id: STREAM_ID });
+      expect(mockContractClient.get_stream_metrics).toHaveBeenCalledWith({
+        stream_id: STREAM_ID,
+      });
       expect(tx.result).toEqual(mockMetrics);
     });
 
-    it('returns correct StreamMetrics shape', async () => {
-      mockContractClient.get_stream_metrics.mockResolvedValue(mockTx(mockMetrics));
+    it("returns correct StreamMetrics shape", async () => {
+      mockContractClient.get_stream_metrics.mockResolvedValue(
+        mockTx(mockMetrics)
+      );
       const tx = await client.getStreamMetrics(STREAM_ID);
-      expect(tx.result).toHaveProperty('pause_count');
-      expect(tx.result).toHaveProperty('total_withdrawn');
-      expect(tx.result).toHaveProperty('withdrawal_count');
+      expect(tx.result).toHaveProperty("pause_count");
+      expect(tx.result).toHaveProperty("total_withdrawn");
+      expect(tx.result).toHaveProperty("withdrawal_count");
     });
   });
 
   // ── getProtocolMetrics ─────────────────────────────────────────────────────
-  describe('getProtocolMetrics', () => {
-    it('delegates to client.get_protocol_metrics', async () => {
+  describe("getProtocolMetrics", () => {
+    it("delegates to client.get_protocol_metrics", async () => {
       const mockMetrics = {
         total_active_streams: 5n,
         total_delegations: 2n,
         total_streams_created: 10n,
         total_tokens_streamed: 50000n,
       };
-      mockContractClient.get_protocol_metrics.mockResolvedValue(mockTx(mockMetrics));
+      mockContractClient.get_protocol_metrics.mockResolvedValue(
+        mockTx(mockMetrics)
+      );
       const tx = await client.getProtocolMetrics();
       expect(mockContractClient.get_protocol_metrics).toHaveBeenCalled();
       expect(tx.result).toEqual(mockMetrics);
@@ -339,8 +437,8 @@ describe('PaymentStreamClient', () => {
   });
 
   // ── getFeeCollector ────────────────────────────────────────────────────────
-  describe('getFeeCollector', () => {
-    it('returns fee collector address', async () => {
+  describe("getFeeCollector", () => {
+    it("returns fee collector address", async () => {
       mockContractClient.get_fee_collector.mockResolvedValue(mockTx(SENDER));
       const tx = await client.getFeeCollector();
       expect(tx.result).toBe(SENDER);
@@ -348,8 +446,8 @@ describe('PaymentStreamClient', () => {
   });
 
   // ── getProtocolFeeRate ─────────────────────────────────────────────────────
-  describe('getProtocolFeeRate', () => {
-    it('returns fee rate as number', async () => {
+  describe("getProtocolFeeRate", () => {
+    it("returns fee rate as number", async () => {
       mockContractClient.get_protocol_fee_rate.mockResolvedValue(mockTx(50));
       const tx = await client.getProtocolFeeRate();
       expect(tx.result).toBe(50);
@@ -357,19 +455,45 @@ describe('PaymentStreamClient', () => {
   });
 
   // ── initialize ─────────────────────────────────────────────────────────────
-  describe('initialize', () => {
-    it('delegates to client.initialize with correct params', async () => {
+  describe("initialize", () => {
+    it("delegates to client.initialize with correct params", async () => {
       mockContractClient.initialize.mockResolvedValue(mockTx());
-      const params = { admin: SENDER, fee_collector: RECIPIENT, general_fee_rate: 10 };
+      const params = {
+        admin: SENDER,
+        fee_collector: RECIPIENT,
+        general_fee_rate: 10,
+      };
       await client.initialize(params);
       expect(mockContractClient.initialize).toHaveBeenCalledWith(params);
     });
 
-    it('propagates AlreadyInitialized error', async () => {
-      mockContractClient.initialize.mockRejectedValue(new Error('AlreadyInitialized'));
+    it("propagates AlreadyInitialized error", async () => {
+      mockContractClient.initialize.mockRejectedValue(
+        new Error("AlreadyInitialized")
+      );
       await expect(
-        client.initialize({ admin: SENDER, fee_collector: RECIPIENT, general_fee_rate: 10 })
-      ).rejects.toThrow('AlreadyInitialized');
+        client.initialize({
+          admin: SENDER,
+          fee_collector: RECIPIENT,
+          general_fee_rate: 10,
+        })
+      ).rejects.toThrow("AlreadyInitialized");
+    });
+
+    it("accepts Address objects for addresses", async () => {
+      mockContractClient.initialize.mockResolvedValue(mockTx());
+      const params = {
+        admin: SENDER,
+        fee_collector: RECIPIENT,
+        general_fee_rate: 10,
+      };
+      const addressParams = {
+        admin: new Address(SENDER),
+        fee_collector: new Address(RECIPIENT),
+        general_fee_rate: 10,
+      };
+      await client.initialize(addressParams);
+      expect(mockContractClient.initialize).toHaveBeenCalledWith(params);
     });
   });
 });

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -4,7 +4,7 @@
  * TypeScript SDK for interacting with Fundable Protocol smart contracts on Stellar.
  */
 
-export const VERSION = "0.1.0";
+export const VERSION = "0.2.0";
 
 // Re-export generated types for Payment Stream
 export * from "./generated/payment-stream/src/index";

--- a/packages/sdk/src/utils/batchDistribution.ts
+++ b/packages/sdk/src/utils/batchDistribution.ts
@@ -9,7 +9,7 @@
  */
 
 import { AssembledTransaction } from '@stellar/stellar-sdk/contract';
-import type { DistributorClient } from '../DistributorClient';
+import type { DistributorClient, AddressParam } from '../DistributorClient';
 
 /**
  * Configuration for batch distribution operations.
@@ -77,16 +77,16 @@ export interface BatchDistributionConfig {
  */
 export interface EqualDistributionParams {
   /** Sender address (must have sufficient token balance). */
-  sender: string;
+  sender: AddressParam;
 
   /** Token contract ID to distribute. */
-  token: string;
+  token: AddressParam;
 
   /** Total amount to distribute across all recipients (in token base units). */
   total_amount: bigint;
 
   /** List of recipient addresses (will be split into batches). */
-  recipients: string[];
+  recipients: AddressParam[];
 
   /** Batch configuration options. */
   config?: BatchDistributionConfig;
@@ -99,13 +99,13 @@ export interface EqualDistributionParams {
  */
 export interface WeightedDistributionParams {
   /** Sender address (must have sufficient token balance). */
-  sender: string;
+  sender: AddressParam;
 
   /** Token contract ID to distribute. */
-  token: string;
+  token: AddressParam;
 
   /** Recipient addresses (will be split into batches along with amounts). */
-  recipients: string[];
+  recipients: AddressParam[];
 
   /** Amount for each recipient, in parallel order with recipients array (in token base units). */
   amounts: bigint[];


### PR DESCRIPTION
I implemented the [SDK] Add support for Address objects in client parameters
closes #186 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated all SDK client methods to accept Stellar Address objects alongside traditional string addresses, providing greater flexibility in parameter handling.

* **Documentation**
  * Enhanced with improved examples demonstrating both address input formats.

* **Tests**
  * Extended test coverage to validate Address object support and error scenarios across all client methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->