### PR TITLE
feat: add reusable mock RPC server for SDK unit tests (#166)

### DIFF
--- a/packages/sdk/src/test-utils/mockRpcServer.ts
+++ b/packages/sdk/src/test-utils/mockRpcServer.ts
@@ -1,0 +1,39 @@
+import { vi } from 'vitest';
+
+export function createMockRpcServer(overrides: Record<string, unknown> = {}) {
+  const mock = {
+    getAccount: vi.fn(),
+    simulateTransaction: vi.fn(),
+    sendTransaction: vi.fn(),
+    getTransaction: vi.fn(),
+    getNetwork: vi.fn(),
+
+    mockSuccess() {
+      this.simulateTransaction.mockResolvedValue({ result: {} });
+      this.sendTransaction.mockResolvedValue({ hash: 'tx123' });
+      this.getTransaction.mockResolvedValue({ status: 'SUCCESS', ledger: 12345 });
+    },
+
+    mockPendingThenSuccess() {
+      this.getTransaction
+        .mockResolvedValueOnce({ status: 'PENDING' })
+        .mockResolvedValueOnce({ status: 'SUCCESS', ledger: 123 });
+    },
+
+    mockFailure() {
+      this.getTransaction.mockResolvedValue({ status: 'FAILED', ledger: 123 });
+    },
+
+    mockTimeout() {
+      this.simulateTransaction.mockRejectedValue(new Error('timeout'));
+    },
+
+    mockMalformed() {
+      this.simulateTransaction.mockResolvedValue({});
+    },
+
+    ...overrides,
+  };
+
+  return mock;
+}

--- a/packages/sdk/src/test-utils/mockRpcServer.ts
+++ b/packages/sdk/src/test-utils/mockRpcServer.ts
@@ -1,39 +1,45 @@
 import { vi } from 'vitest';
 
-export function createMockRpcServer(overrides: Record<string, unknown> = {}) {
-  const mock = {
-    getAccount: vi.fn(),
-    simulateTransaction: vi.fn(),
-    sendTransaction: vi.fn(),
-    getTransaction: vi.fn(),
-    getNetwork: vi.fn(),
+const mock = {
+  getAccount: vi.fn(),
+  simulateTransaction: vi.fn(),
+  sendTransaction: vi.fn(),
+  getTransaction: vi.fn(),
+  getNetwork: vi.fn(),
 
-    mockSuccess() {
-      this.simulateTransaction.mockResolvedValue({ result: {} });
-      this.sendTransaction.mockResolvedValue({ hash: 'tx123' });
-      this.getTransaction.mockResolvedValue({ status: 'SUCCESS', ledger: 12345 });
-    },
+  mockSuccess() {
+    this.simulateTransaction.mockResolvedValue({ result: {} });
+    this.sendTransaction.mockResolvedValue({ hash: 'tx123' });
+    this.getTransaction.mockResolvedValue({ status: 'SUCCESS', ledger: 12345 });
+  },
 
-    mockPendingThenSuccess() {
-      this.getTransaction
-        .mockResolvedValueOnce({ status: 'PENDING' })
-        .mockResolvedValueOnce({ status: 'SUCCESS', ledger: 123 });
-    },
+  mockPendingThenSuccess() {
+    this.getTransaction
+      .mockResolvedValueOnce({ status: 'PENDING' })
+      .mockResolvedValueOnce({ status: 'SUCCESS', ledger: 123 });
+  },
 
-    mockFailure() {
-      this.getTransaction.mockResolvedValue({ status: 'FAILED', ledger: 123 });
-    },
+  mockFailure() {
+    this.getTransaction.mockResolvedValue({ status: 'FAILED', ledger: 123 });
+  },
 
-    mockTimeout() {
-      this.simulateTransaction.mockRejectedValue(new Error('timeout'));
-    },
+  mockTimeout() {
+    this.simulateTransaction.mockRejectedValue(new Error('timeout'));
+  },
 
-    mockMalformed() {
-      this.simulateTransaction.mockResolvedValue({});
-    },
+  mockMalformed() {
+    this.simulateTransaction.mockResolvedValue({});
+  },
+};
 
-    ...overrides,
-  };
+vi.mock('@stellar/stellar-sdk/rpc', () => ({
+  Server: vi.fn(() => mock),
+  Api: {
+    isSimulationError: (r: Record<string, unknown>) => r?.error !== undefined,
+    isSimulationSuccess: (r: Record<string, unknown>) => r?.error === undefined,
+    GetTransactionStatus: { NOT_FOUND: 'NOT_FOUND', SUCCESS: 'SUCCESS', FAILED: 'FAILED' },
+  },
+}));
 
-  return mock;
-}
+export function createMockRpcServer() { return mock; }
+export function resetMockRpcServer() { Object.values(mock).forEach((fn) => { if (typeof fn === 'function' && 'mockReset' in fn) fn.mockReset(); }); }


### PR DESCRIPTION
Closes #166

 What this PR does
Adds a reusable mock RPC server for SDK unit tests to eliminate network dependency and duplication.

 Changes
- Created `packages/sdk/src/test-utils/mockRpcServer.ts` — central mock RPC server
- Mocks `@stellar/stellar-sdk/rpc` at module level with `vi.mock()` — no per-test setup needed
- Exposes `getAccount`, `simulateTransaction`, `sendTransaction`, `getTransaction`, `getNetwork` mocks
- Includes helpers: `createMockRpcServer()`, `resetMockRpcServer()`
- Built-in scenarios: `mockSuccess()`, `mockFailure()`, `mockTimeout()`, `mockMalformed()`, `mockPendingThenSuccess()`

 Benefits
- ✅ No real RPC calls during unit tests
- ✅ Single source of truth for RPC mocking
- ✅ Eliminates duplicated `vi.mock` setups across test files
- ✅ Consistent mock behavior across all SDK tests
- ✅ Tests run faster and are network-independent

 Usage
```ts
import { createMockRpcServer, resetMockRpcServer } from '../test-utils/mockRpcServer';

const rpc = createMockRpcServer();

beforeEach(() => {
  resetMockRpcServer();
  rpc.mockSuccess();
});

it('handles timeout', () => {
  rpc.mockTimeout();
  // ...
});
/claim #166



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a mock RPC server testing utility for simulating various transaction scenarios including success, pending states, failures, timeouts, and error responses to improve test coverage for RPC interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
/claim #166