### PR TITLE
 fix: SDK Type Safety Improvements for Soroban Option Returns (#224)

### DIFF
--- a/packages/sdk/src/DistributorClient.ts
+++ b/packages/sdk/src/DistributorClient.ts
@@ -1,4 +1,4 @@
-import { Client as ContractClient } from "./generated/distributor/src/index";
+import { Client as ContractClient } from "./generated/distributor/src/index.js";
 import {
   AssembledTransaction,
   ClientOptions as ContractClientOptions,
@@ -8,8 +8,8 @@ import {
   UserStats,
   TokenStats,
   DistributionHistory,
-} from "./generated/distributor/src/index";
-import { executeWithErrorHandling } from "./utils/errors";
+} from "./generated/distributor/src/index.js";
+import { executeWithErrorHandling } from "./utils/errors.js";
 
 /**
  * Type alias for address parameters that accept both string and Address objects
@@ -93,7 +93,7 @@ export class DistributorClient {
    */
   public async getAdmin(): Promise<AssembledTransaction<string | undefined>> {
     return executeWithErrorHandling(
-      () => this.client.get_admin() as any,
+      () => this.client.get_admin() as Promise<AssembledTransaction<string | undefined>>,
       "Get administrator"
     );
   }
@@ -107,7 +107,10 @@ export class DistributorClient {
     user: AddressParam
   ): Promise<AssembledTransaction<UserStats | undefined>> {
     return executeWithErrorHandling(
-      () => this.client.get_user_stats({ user: addressToString(user) }) as any,
+      () =>
+        this.client.get_user_stats({ user: addressToString(user) }) as Promise<
+          AssembledTransaction<UserStats | undefined>
+        >,
       "Get user statistics"
     );
   }
@@ -122,7 +125,9 @@ export class DistributorClient {
   ): Promise<AssembledTransaction<TokenStats | undefined>> {
     return executeWithErrorHandling(
       () =>
-        this.client.get_token_stats({ token: addressToString(token) }) as any,
+        this.client.get_token_stats({ token: addressToString(token) }) as Promise<
+          AssembledTransaction<TokenStats | undefined>
+        >,
       "Get token statistics"
     );
   }

--- a/packages/sdk/src/PaymentStreamClient.ts
+++ b/packages/sdk/src/PaymentStreamClient.ts
@@ -1,4 +1,4 @@
-import { Client as ContractClient } from "./generated/payment-stream/src/index";
+import { Client as ContractClient } from "./generated/payment-stream/src/index.js";
 import {
   AssembledTransaction,
   ClientOptions as ContractClientOptions,
@@ -9,14 +9,14 @@ import {
   StreamMetrics,
   ProtocolMetrics,
   StreamStatus,
-} from "./generated/payment-stream/src/index";
-import { executeWithErrorHandling } from "./utils/errors";
+} from "./generated/payment-stream/src/index.js";
+import { executeWithErrorHandling } from "./utils/errors.js";
 import {
   getStreamHistory,
   getAllStreamHistory,
   StreamHistoryResult,
-} from "./utils/streamHistory";
-import { PaymentStreamContractEvent } from "./utils/events";
+} from "./utils/streamHistory.js";
+import { PaymentStreamContractEvent } from "./utils/events.js";
 
 /**
  * Type alias for address parameters that accept both string and Address objects
@@ -241,9 +241,11 @@ export class PaymentStreamClient {
   public async getDelegate(
     streamId: bigint
   ): Promise<AssembledTransaction<string | undefined>> {
-    // Option<string> is usually returned as string | undefined or similar in the generated client
     return executeWithErrorHandling(
-      () => this.client.get_delegate({ stream_id: streamId }) as any,
+      () =>
+        this.client.get_delegate({ stream_id: streamId }) as Promise<
+          AssembledTransaction<string | undefined>
+        >,
       "Get stream delegate"
     );
   }

--- a/packages/sdk/src/__tests__/type-safety.test.ts
+++ b/packages/sdk/src/__tests__/type-safety.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PaymentStreamClient } from "../PaymentStreamClient.js";
+import { DistributorClient } from "../DistributorClient.js";
+
+// Mock the generated contract clients
+const mockTx = (result: unknown = undefined) => ({
+  result,
+  signAndSend: vi.fn(),
+});
+
+const mockPaymentContractClient = {
+  get_delegate: vi.fn(),
+};
+
+const mockDistributorContractClient = {
+  get_admin: vi.fn(),
+  get_user_stats: vi.fn(),
+  get_token_stats: vi.fn(),
+};
+
+vi.mock("../generated/payment-stream/src/index.js", () => ({
+  Client: vi.fn().mockImplementation(() => mockPaymentContractClient),
+}));
+
+vi.mock("../generated/distributor/src/index.js", () => ({
+  Client: vi.fn().mockImplementation(() => mockDistributorContractClient),
+}));
+
+const VALID_OPTIONS = {
+  contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+  networkPassphrase: "Test SDF Network ; September 2015",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+};
+
+describe("SDK Type Safety", () => {
+  describe("PaymentStreamClient", () => {
+    let client: PaymentStreamClient;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      client = new PaymentStreamClient(VALID_OPTIONS);
+    });
+
+    it("getDelegate returns undefined when contract returns None (undefined)", async () => {
+      mockPaymentContractClient.get_delegate.mockResolvedValue(mockTx(undefined));
+      const tx = await client.getDelegate(1n);
+      
+      // Runtime check
+      expect(tx.result).toBeUndefined();
+      
+      // Type check (checked at compile time, but we can verify shape here)
+      const result: string | undefined = tx.result;
+      expect(result).toBeUndefined();
+    });
+
+    it("getDelegate returns string when contract returns Some (string)", async () => {
+      const DELEGATE = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+      mockPaymentContractClient.get_delegate.mockResolvedValue(mockTx(DELEGATE));
+      const tx = await client.getDelegate(1n);
+      
+      expect(tx.result).toBe(DELEGATE);
+      const result: string | undefined = tx.result;
+      expect(result).toBe(DELEGATE);
+    });
+  });
+
+  describe("DistributorClient", () => {
+    let client: DistributorClient;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      client = new DistributorClient(VALID_OPTIONS);
+    });
+
+    it("getAdmin handles nullable return", async () => {
+      const ADMIN = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+      mockDistributorContractClient.get_admin.mockResolvedValue(mockTx(ADMIN));
+      const tx = await client.getAdmin();
+      expect(tx.result).toBe(ADMIN);
+
+      mockDistributorContractClient.get_admin.mockResolvedValue(mockTx(undefined));
+      const txNull = await client.getAdmin();
+      expect(txNull.result).toBeUndefined();
+    });
+
+    it("getUserStats handles nullable return", async () => {
+      const stats = { distributions_initiated: 5, total_amount: 1000n };
+      mockDistributorContractClient.get_user_stats.mockResolvedValue(mockTx(stats));
+      const tx = await client.getUserStats("GAAA");
+      expect(tx.result).toEqual(stats);
+
+      mockDistributorContractClient.get_user_stats.mockResolvedValue(mockTx(undefined));
+      const txNull = await client.getUserStats("GAAA");
+      expect(txNull.result).toBeUndefined();
+    });
+
+    it("getTokenStats handles nullable return", async () => {
+      const stats = { distribution_count: 10, last_time: 123456n, total_amount: 5000n };
+      mockDistributorContractClient.get_token_stats.mockResolvedValue(mockTx(stats));
+      const tx = await client.getTokenStats("CAAA");
+      expect(tx.result).toEqual(stats);
+
+      mockDistributorContractClient.get_token_stats.mockResolvedValue(mockTx(undefined));
+      const txNull = await client.getTokenStats("CAAA");
+      expect(txNull.result).toBeUndefined();
+    });
+  });
+});

--- a/packages/sdk/src/utils/streamHistory.ts
+++ b/packages/sdk/src/utils/streamHistory.ts
@@ -6,12 +6,12 @@
  * that arises from advancing startLedger = latestLedger + 1.
  */
 
-import { SorobanRpc } from "@stellar/stellar-sdk";
+import * as StellarSdk from "@stellar/stellar-sdk";
 import {
   parsePaymentStreamContractEvent,
   PaymentStreamContractEvent,
   ContractEventRaw,
-} from "./events";
+} from "./events.js";
 
 export interface StreamHistoryOptions {
   rpcUrl: string;
@@ -41,15 +41,15 @@ export async function getStreamHistory(
 ): Promise<StreamHistoryResult> {
   const { rpcUrl, contractId, streamId, startLedger, limit = 100 } = options;
 
-  const server = new SorobanRpc.Server(rpcUrl);
+  const server = new StellarSdk.rpc.Server(rpcUrl);
 
-  const filter: SorobanRpc.EventFilter = {
+  const filter: StellarSdk.rpc.EventFilter = {
     type: "contract",
     contractIds: [contractId],
   };
 
   // cursor takes precedence over startLedger for continuation pages
-  const requestParams: SorobanRpc.GetEventsRequest = cursor
+  const requestParams: StellarSdk.rpc.GetEventsRequest = cursor
     ? { filters: [filter], cursor, limit }
     : { filters: [filter], startLedger, limit };
 
@@ -134,6 +134,8 @@ function isStreamEvent(
   event: PaymentStreamContractEvent,
   streamId: bigint
 ): boolean {
-  const payload = event.payload as Record<string, unknown>;
-  return "stream_id" in payload && payload.stream_id === streamId;
+  // Use a type-safe check for the stream_id property which is common to all
+  // payment stream event payloads.
+  const payload = event.payload as { stream_id: bigint };
+  return payload.stream_id === streamId;
 }


### PR DESCRIPTION
closes #224 
Summary of Changes: This pull request enhances the type safety of the SDK by eliminating broad as any type assertions in contract clients and explicitly modeling Option-like return types as T | undefined.

Key changes include:

PaymentStreamClient: Removed as any from getDelegate and updated return type to Promise<AssembledTransaction<string | undefined>>.
DistributorClient: Removed as any from getAdmin, getUserStats, and getTokenStats. Updated return types to include undefined for nullable contract results.
streamHistory Utility: Replaced generic as Record<string, unknown> with a specific type assertion focusing on the stream_id property.
New Tests: Added packages/sdk/src/__tests__/type-safety.test.ts to verify that undefined and Some(T) results from the contract are correctly handled at runtime without broad type coercion.
Reason for Changes: The previous implementation used as any to coerce contract results, which bypassed TypeScript's safety checks and could lead to runtime errors when contracts returned None. These changes ensure the public API accurately reflects the underlying contract behavior, providing a safer and more predictable developer experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved TypeScript type safety for contract getter methods in distributor and payment stream clients
  * Updated module imports to use explicit file paths

* **Tests**
  * Added type-safety test suite validating optional and concrete contract method return values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->