### PR TITLE
fix(sdk): align DistributorClient stats address docs

### DIFF
--- a/packages/sdk/src/DistributorClient.ts
+++ b/packages/sdk/src/DistributorClient.ts
@@ -100,14 +100,12 @@ export class DistributorClient {
 
   /**
    * Get stats for a specific user.
-   * @param user The address of the user, or an object containing the user address.
+   * @param user The address of the user.
    * @throws {FundableStellarError} If fetch fails with a human-readable error message
    */
   public async getUserStats(
     user: AddressParam
   ): Promise<AssembledTransaction<UserStats | undefined>> {
-    const actualUser = typeof user === "object" ? user.user : user;
-
     return executeWithErrorHandling(
       () =>
         this.client.get_user_stats({ user: addressToString(user) }) as Promise<
@@ -119,14 +117,12 @@ export class DistributorClient {
 
   /**
    * Get stats for a specific token.
-   * @param token The address of the token (contract ID), or an object containing the token address.
+   * @param token The address of the token contract.
    * @throws {FundableStellarError} If fetch fails with a human-readable error message
    */
   public async getTokenStats(
     token: AddressParam
   ): Promise<AssembledTransaction<TokenStats | undefined>> {
-    const actualToken = typeof token === "object" ? token.token : token;
-
     return executeWithErrorHandling(
       () =>
         this.client.get_token_stats({ token: addressToString(token) }) as Promise<

--- a/packages/sdk/src/__tests__/overloads.test.ts
+++ b/packages/sdk/src/__tests__/overloads.test.ts
@@ -207,31 +207,11 @@ describe("Client Method Overloads", () => {
       expect(result).toBe(mockResult);
     });
 
-    it("getUserStats accepts object parameter", async () => {
-      const mockResult = { signAndSend: vi.fn() };
-      mockDistributorClient.get_user_stats.mockResolvedValue(mockResult);
-
-      const result = await distributorClient.getUserStats({ user });
-
-      expect(mockDistributorClient.get_user_stats).toHaveBeenCalledWith({ user });
-      expect(result).toBe(mockResult);
-    });
-
     it("getTokenStats accepts individual parameters", async () => {
       const mockResult = { signAndSend: vi.fn() };
       mockDistributorClient.get_token_stats.mockResolvedValue(mockResult);
 
       const result = await distributorClient.getTokenStats(token);
-
-      expect(mockDistributorClient.get_token_stats).toHaveBeenCalledWith({ token });
-      expect(result).toBe(mockResult);
-    });
-
-    it("getTokenStats accepts object parameter", async () => {
-      const mockResult = { signAndSend: vi.fn() };
-      mockDistributorClient.get_token_stats.mockResolvedValue(mockResult);
-
-      const result = await distributorClient.getTokenStats({ token });
 
       expect(mockDistributorClient.get_token_stats).toHaveBeenCalledWith({ token });
       expect(result).toBe(mockResult);


### PR DESCRIPTION
## Summary

- Remove unused `actualUser` / `actualToken` locals from `DistributorClient` stats methods.
- Update `getUserStats` / `getTokenStats` JSDoc to match the `AddressParam` signature.
- Drop stale overload tests for unsupported wrapper-object inputs.

Fixes #256.

## Validation

- `corepack pnpm --filter @fundable/sdk exec vitest --run src/__tests__/overloads.test.ts`
- `git diff --check`

## Notes

Broader SDK checks currently fail outside this patch:

- `corepack pnpm --filter @fundable/sdk build` fails on existing `src/utils/GasEstimator.ts` syntax errors.
- `corepack pnpm --filter @fundable/sdk test -- --runInBand` fails in unrelated GasEstimator, BalanceWatcher, deployer, transaction, stream history, and error utility tests.