### PR TITLE
Fix SDK security issues for RPC transport, batch sizing, and deploy salt

### DIFF
--- a/apps/web/src/hooks/use-distribution-transaction.ts
+++ b/apps/web/src/hooks/use-distribution-transaction.ts
@@ -7,6 +7,7 @@ import { useWallet } from '@/providers/StellarWalletProvider';
 import { notify } from '@/utils/notification';
 import { DISTRIBUTOR_CONTRACT_ID, SOROBAN_RPC_URL, NETWORK_PASSPHRASE } from '@/lib/constants';
 import { amountToStroops } from '@/utils/amount-validation';
+import { getStellarServerOptions } from '@/utils/rpc-connection-options';
 import type { DistributionState } from '@/types/distribution';
 
 const IS_MAINNET = process.env.NEXT_PUBLIC_STELLAR_NETWORK === 'public';
@@ -34,7 +35,7 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
  */
 async function accountExists(address: string): Promise<boolean> {
   try {
-    const horizon = new Horizon.Server(HORIZON_URL, { allowHttp: true });
+    const horizon = new Horizon.Server(HORIZON_URL, getStellarServerOptions(HORIZON_URL));
     await withTimeout(horizon.loadAccount(address), ACCOUNT_CHECK_TIMEOUT_MS, address);
     return true;
   } catch (err) {
@@ -55,7 +56,7 @@ async function checkSenderBalance(
   requiredAmount: bigint
 ): Promise<{ ok: boolean; reason?: string }> {
   try {
-    const horizon = new Horizon.Server(HORIZON_URL, { allowHttp: true });
+    const horizon = new Horizon.Server(HORIZON_URL, getStellarServerOptions(HORIZON_URL));
     const account = await horizon.loadAccount(senderAddress);
 
     if (tokenAddress === 'native') {

--- a/apps/web/src/services/contract.deployer.ts
+++ b/apps/web/src/services/contract.deployer.ts
@@ -8,6 +8,7 @@ import {
   StrKey,
 } from '@stellar/stellar-sdk';
 import { Server as RpcServer, Api, assembleTransaction } from '@stellar/stellar-sdk/rpc';
+import { getStellarServerOptions } from '@/utils/rpc-connection-options';
 
 interface DeployConfig {
   rpcUrl: string;
@@ -19,7 +20,7 @@ export class ContractDeployer {
   private networkPassphrase: string;
 
   constructor(config: DeployConfig) {
-    this.rpcServer = new RpcServer(config.rpcUrl, { allowHttp: true });
+    this.rpcServer = new RpcServer(config.rpcUrl, getStellarServerOptions(config.rpcUrl));
     this.networkPassphrase = config.networkPassphrase;
   }
 

--- a/apps/web/src/services/stellar.service.ts
+++ b/apps/web/src/services/stellar.service.ts
@@ -56,6 +56,7 @@ import {
   parseError,
 } from './errors';
 import { isAbortError, withAbortSignal, withRetry } from '@/utils/retry';
+import { getStellarServerOptions } from '@/utils/rpc-connection-options';
 
 // Default configuration values
 const DEFAULT_TIMEOUT = 30; // seconds
@@ -80,8 +81,14 @@ export class StellarService {
   private readonly maxRetries: number;
 
   constructor(config: StellarServiceConfig) {
-    this.rpcServer = new RpcServer(config.network.rpcUrl, { allowHttp: true });
-    this.horizonServer = new Horizon.Server(config.network.horizonUrl, { allowHttp: true });
+    this.rpcServer = new RpcServer(
+      config.network.rpcUrl,
+      getStellarServerOptions(config.network.rpcUrl)
+    );
+    this.horizonServer = new Horizon.Server(
+      config.network.horizonUrl,
+      getStellarServerOptions(config.network.horizonUrl)
+    );
     this.networkPassphrase = config.network.networkPassphrase;
     this.paymentStreamContractId = config.contracts.paymentStream;
     this.distributorContractId = config.contracts.distributor;

--- a/apps/web/src/utils/rpc-connection-options.ts
+++ b/apps/web/src/utils/rpc-connection-options.ts
@@ -1,0 +1,19 @@
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+
+function isLoopbackHttpUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' && LOOPBACK_HOSTNAMES.has(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Stellar SDK server options for the web app.
+ * Plain HTTP is only enabled in non-production builds against loopback hosts.
+ */
+export function getStellarServerOptions(url: string): { allowHttp: boolean } {
+  const isDev = process.env.NODE_ENV !== 'production';
+  return { allowHttp: isDev && isLoopbackHttpUrl(url) };
+}

--- a/packages/sdk/DEVELOPMENT_GUIDE.md
+++ b/packages/sdk/DEVELOPMENT_GUIDE.md
@@ -191,6 +191,22 @@ Follow the [STYLE_GUIDE.md](../../STYLE_GUIDE.md) for general TypeScript convent
 
 ## Troubleshooting
 
+### Local Soroban RPC over plain HTTP
+
+For local development against a Soroban node at `http://localhost:8000` (or `http://127.0.0.1`, `http://[::1]`), pass `allowHttp: true` explicitly. Remote `http://` URLs are rejected by default.
+
+```typescript
+import { ContractDeployer } from '@fundable/sdk';
+
+const deployer = new ContractDeployer({
+  rpcUrl: 'http://localhost:8000',
+  allowHttp: true,
+  networkPassphrase: 'Standalone Network ; February 2017',
+});
+```
+
+`allowHttp` defaults to `false`. Production integrations should use `https://` RPC endpoints only.
+
 ### "Cannot find module '@stellar/stellar-sdk'"
 
 Ensure the peer dependency is installed in your consuming project:

--- a/packages/sdk/src/__tests__/ContractDeployer.edge.test.ts
+++ b/packages/sdk/src/__tests__/ContractDeployer.edge.test.ts
@@ -613,6 +613,34 @@ describe('ContractDeployer — edge cases', () => {
     });
   });
 
+  // ── Cryptographic salt generation ─────────────────────────────────────────
+  describe('randomSalt', () => {
+    it('generates distinct 32-byte salts on consecutive calls', () => {
+      const randomSalt = (deployer as unknown as { randomSalt: () => Buffer }).randomSalt.bind(
+        deployer
+      );
+      const salt1 = randomSalt();
+      const salt2 = randomSalt();
+
+      expect(salt1).toHaveLength(32);
+      expect(salt2).toHaveLength(32);
+      expect(Buffer.compare(salt1, salt2)).not.toBe(0);
+    });
+
+    it('does not derive salts from Math.random', () => {
+      const mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const randomSalt = (deployer as unknown as { randomSalt: () => Buffer }).randomSalt.bind(
+        deployer
+      );
+
+      const salt = randomSalt();
+      expect(salt).toHaveLength(32);
+      expect(mathRandomSpy).not.toHaveBeenCalled();
+
+      mathRandomSpy.mockRestore();
+    });
+  });
+
   // ── Error class hierarchy ──────────────────────────────────────────────────
   describe('error class hierarchy', () => {
     it('all deployer errors extend DeployerError', () => {

--- a/packages/sdk/src/__tests__/ContractDeployer.test.ts
+++ b/packages/sdk/src/__tests__/ContractDeployer.test.ts
@@ -451,4 +451,25 @@ describe('ContractDeployer', () => {
       expect(passphrase).toBe('Test SDF Network ; September 2015');
     });
   });
+
+  describe('RPC URL security', () => {
+    it('rejects non-loopback http:// rpcUrl at construction', () => {
+      expect(
+        () =>
+          new ContractDeployer({
+            rpcUrl: 'http://evil.example/rpc',
+          })
+      ).toThrow(/Insecure RPC URL rejected/);
+    });
+
+    it('allows loopback http:// rpcUrl with allowHttp: true', () => {
+      expect(
+        () =>
+          new ContractDeployer({
+            rpcUrl: 'http://localhost:8000',
+            allowHttp: true,
+          })
+      ).not.toThrow();
+    });
+  });
 });

--- a/packages/sdk/src/__tests__/batchDistribution.test.ts
+++ b/packages/sdk/src/__tests__/batchDistribution.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createBatches,
+  prepareBatchEqualDistribution,
+  prepareBatchWeightedDistribution,
+} from '../utils/batchDistribution';
+
+const mockDistributeEqual = vi.fn();
+const mockDistributeWeighted = vi.fn();
+
+const mockClient = {
+  distributeEqual: mockDistributeEqual,
+  distributeWeighted: mockDistributeWeighted,
+} as any;
+
+describe('createBatches', () => {
+  it('splits arrays into fixed-size batches', () => {
+    expect(createBatches([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it.each([0, -1, 1.5])('rejects invalid batchSize %s', (batchSize) => {
+    expect(() => createBatches([1, 2, 3], batchSize)).toThrow(
+      /batchSize must be a positive integer/
+    );
+  });
+});
+
+describe('prepareBatchEqualDistribution', () => {
+  beforeEach(() => {
+    mockDistributeEqual.mockReset();
+    mockDistributeEqual.mockResolvedValue({ id: 'tx' });
+  });
+
+  it('rejects invalid maxRecipientsPerBatch before RPC calls', async () => {
+    await expect(
+      prepareBatchEqualDistribution(mockClient, {
+        sender: 'GAAAA',
+        token: 'native',
+        total_amount: 100n,
+        recipients: ['GAAAA', 'GBBBB'],
+        config: { maxRecipientsPerBatch: 0 },
+      })
+    ).rejects.toThrow(/config\.maxRecipientsPerBatch must be a positive integer/);
+
+    expect(mockDistributeEqual).not.toHaveBeenCalled();
+  });
+});
+
+describe('prepareBatchWeightedDistribution', () => {
+  beforeEach(() => {
+    mockDistributeWeighted.mockReset();
+    mockDistributeWeighted.mockResolvedValue({ id: 'tx' });
+  });
+
+  it('rejects invalid maxRecipientsPerBatch before RPC calls', async () => {
+    await expect(
+      prepareBatchWeightedDistribution(mockClient, {
+        sender: 'GAAAA',
+        token: 'native',
+        recipients: ['GAAAA', 'GBBBB'],
+        amounts: [100n, 200n],
+        config: { maxRecipientsPerBatch: -1 },
+      })
+    ).rejects.toThrow(/config\.maxRecipientsPerBatch must be a positive integer/);
+
+    expect(mockDistributeWeighted).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk/src/__tests__/rpcConnectionOptions.test.ts
+++ b/packages/sdk/src/__tests__/rpcConnectionOptions.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  assertSecureRpcUrl,
+  isLoopbackHttpUrl,
+  resolveRpcServerOptions,
+} from '../utils/rpcConnectionOptions';
+
+describe('rpcConnectionOptions', () => {
+  describe('isLoopbackHttpUrl', () => {
+    it.each([
+      'http://localhost:8000',
+      'http://127.0.0.1:8000',
+      'http://[::1]:8000',
+    ])('returns true for %s', (url) => {
+      expect(isLoopbackHttpUrl(url)).toBe(true);
+    });
+
+    it.each([
+      'https://localhost:8000',
+      'http://example.com',
+      'http://192.168.1.1',
+      'https://soroban-testnet.stellar.org',
+    ])('returns false for %s', (url) => {
+      expect(isLoopbackHttpUrl(url)).toBe(false);
+    });
+  });
+
+  describe('assertSecureRpcUrl', () => {
+    it('allows https URLs', () => {
+      expect(() =>
+        assertSecureRpcUrl('https://soroban-testnet.stellar.org')
+      ).not.toThrow();
+    });
+
+    it('allows loopback http URLs', () => {
+      expect(() => assertSecureRpcUrl('http://localhost:8000')).not.toThrow();
+    });
+
+    it('rejects non-loopback http URLs', () => {
+      expect(() => assertSecureRpcUrl('http://evil.example/rpc')).toThrow(
+        /Insecure RPC URL rejected/
+      );
+    });
+  });
+
+  describe('resolveRpcServerOptions', () => {
+    it('defaults allowHttp to false for https URLs', () => {
+      expect(
+        resolveRpcServerOptions('https://soroban-testnet.stellar.org')
+      ).toEqual({ allowHttp: false });
+    });
+
+    it('defaults allowHttp to false for loopback http URLs', () => {
+      expect(resolveRpcServerOptions('http://localhost:8000')).toEqual({
+        allowHttp: false,
+      });
+    });
+
+    it('enables allowHttp for loopback http URLs when explicitly requested', () => {
+      expect(
+        resolveRpcServerOptions('http://localhost:8000', { allowHttp: true })
+      ).toEqual({ allowHttp: true });
+    });
+
+    it('rejects allowHttp for non-loopback http URLs', () => {
+      expect(() =>
+        resolveRpcServerOptions('http://evil.example/rpc', { allowHttp: true })
+      ).toThrow(/Insecure RPC URL rejected/);
+    });
+
+    it('rejects non-loopback http URLs even without allowHttp', () => {
+      expect(() => resolveRpcServerOptions('http://evil.example/rpc')).toThrow(
+        /Insecure RPC URL rejected/
+      );
+    });
+  });
+});

--- a/packages/sdk/src/deployer/ContractDeployer.ts
+++ b/packages/sdk/src/deployer/ContractDeployer.ts
@@ -28,6 +28,8 @@ import {
   FeeEstimationError,
   DeploymentTimeoutError,
 } from './errors';
+import { resolveRpcServerOptions } from '../utils/rpcConnectionOptions';
+import { secureRandomBytes } from '../utils/secureRandom';
 
 const DEFAULT_BASE_FEE = '100';
 const DEFAULT_TIMEOUT = 60;
@@ -70,7 +72,10 @@ export class ContractDeployer {
   private passphrasePromise: Promise<string> | undefined;
 
   constructor(config: DeployerConfig) {
-    this.rpc = new Server(config.rpcUrl, { allowHttp: true });
+    this.rpc = new Server(
+      config.rpcUrl,
+      resolveRpcServerOptions(config.rpcUrl, { allowHttp: config.allowHttp })
+    );
     this.networkPassphrase = config.networkPassphrase;
     this.baseFee = config.baseFee ?? DEFAULT_BASE_FEE;
     this.timeoutSeconds = config.timeoutSeconds ?? DEFAULT_TIMEOUT;
@@ -552,9 +557,7 @@ export class ContractDeployer {
   }
 
   private randomSalt(): Buffer {
-    const buf = Buffer.alloc(32);
-    for (let i = 0; i < 32; i++) buf[i] = Math.floor(Math.random() * 256);
-    return buf;
+    return secureRandomBytes(32);
   }
 }
 

--- a/packages/sdk/src/deployer/types.ts
+++ b/packages/sdk/src/deployer/types.ts
@@ -137,6 +137,15 @@ export interface DeployerConfig {
    * @default 60
    */
   timeoutSeconds?: number;
+
+  /**
+   * Opt in to plain HTTP for local loopback RPC URLs (e.g. `http://localhost:8000`).
+   *
+   * Defaults to `false`. Remote `http://` URLs are always rejected regardless of this flag.
+   *
+   * @default false
+   */
+  allowHttp?: boolean;
 }
 
 /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -39,6 +39,7 @@ export * from "./utils/streamHistory";
 export * from "./utils/BalanceWatcher";
 export * from "./utils/transactions";
 export * from "./utils/GasEstimator";
+export * from "./utils/rpcConnectionOptions";
 
 // Export error handling utilities
 export {

--- a/packages/sdk/src/utils/GasEstimator.ts
+++ b/packages/sdk/src/utils/GasEstimator.ts
@@ -1,5 +1,6 @@
 import { xdr } from "@stellar/stellar-sdk";
 import { Server, Api } from "@stellar/stellar-sdk/rpc";
+import { resolveRpcServerOptions } from "./rpcConnectionOptions";
 
 const DEFAULT_BASE_FEE = "100";
 const DEFAULT_RESOURCE_BUFFER = 1.2;
@@ -28,6 +29,8 @@ export interface GasEstimatorOptions {
   congestionBuffer?: number;
   /** Multiplier applied to fee recommendations under high/severe congestion. Defaults to 1.35. */
   highCongestionBuffer?: number;
+  /** Opt in to plain HTTP for local loopback RPC URLs. Defaults to false. */
+  allowHttp?: boolean;
 }
 
 export type CongestionLevel =
@@ -73,17 +76,6 @@ export interface GasEstimate {
   feeStats?: unknown;
 }
 
-/**
- * Estimates Soroban transaction fees and resource limits from simulation data
- * plus current RPC fee statistics when available.
- */
-export class GasEstimator {
-  private readonly rpc: GasEstimatorRpc;
-  private readonly baseFee: string;
-  private readonly resourceBuffer: number;
-  private readonly congestionBuffer: number;
-  private readonly highCongestionBuffer: number;
-
 function assertStroopString(value: string, name: string): string {
   if (!/^\d+$/.test(value)) {
     throw new Error(`${name} must be a non-negative integer string in stroops`);
@@ -98,12 +90,26 @@ function assertFinitePositiveNumber(value: number, name: string): number {
   return value;
 }
 
+/**
+ * Estimates Soroban transaction fees and resource limits from simulation data
+ * plus current RPC fee statistics when available.
+ */
+export class GasEstimator {
+  private readonly rpc: GasEstimatorRpc;
+  private readonly baseFee: string;
+  private readonly resourceBuffer: number;
+  private readonly congestionBuffer: number;
+  private readonly highCongestionBuffer: number;
+
   constructor(options: GasEstimatorOptions) {
     if (!options.rpc && !options.rpcUrl) {
       throw new Error("GasEstimator requires either rpc or rpcUrl");
     }
 
-    this.rpc = options.rpc ?? new Server(options.rpcUrl!, { allowHttp: true });
+    this.rpc = options.rpc ?? new Server(
+      options.rpcUrl!,
+      resolveRpcServerOptions(options.rpcUrl!, { allowHttp: options.allowHttp })
+    );
     this.baseFee = assertStroopString(
       options.baseFee ?? DEFAULT_BASE_FEE,
       "baseFee"

--- a/packages/sdk/src/utils/batchDistribution.ts
+++ b/packages/sdk/src/utils/batchDistribution.ts
@@ -11,6 +11,12 @@
 import { AssembledTransaction } from '@stellar/stellar-sdk/contract';
 import type { DistributorClient, AddressParam } from '../DistributorClient';
 
+function assertPositiveInt(n: number, name: string): void {
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`${name} must be a positive integer (got ${n})`);
+  }
+}
+
 /**
  * Configuration for batch distribution operations.
  * 
@@ -169,7 +175,7 @@ export interface BatchDistributionResult {
  * @returns Promise containing batched transactions and split recipient lists
  * 
  * @throws {Error} If recipients array is empty
- * @throws {Error} If recipient count doesn't match amounts length (for weighted)
+ * @throws {Error} If maxRecipientsPerBatch is not a positive integer
  * 
  * @example
  * ```ts
@@ -197,6 +203,7 @@ export async function prepareBatchEqualDistribution(
 ): Promise<BatchDistributionResult> {
   const { sender, token, total_amount, recipients, config = {} } = params;
   const maxRecipientsPerBatch = config.maxRecipientsPerBatch ?? 100;
+  assertPositiveInt(maxRecipientsPerBatch, 'config.maxRecipientsPerBatch');
 
   if (recipients.length === 0) {
     throw new Error('Recipients array cannot be empty');
@@ -246,6 +253,7 @@ export async function prepareBatchEqualDistribution(
  * 
  * @throws {Error} If recipients array is empty
  * @throws {Error} If recipients and amounts arrays have different lengths
+ * @throws {Error} If maxRecipientsPerBatch is not a positive integer
  * 
  * @example
  * ```ts
@@ -280,6 +288,7 @@ export async function prepareBatchWeightedDistribution(
 ): Promise<BatchDistributionResult> {
   const { sender, token, recipients, amounts, config = {} } = params;
   const maxRecipientsPerBatch = config.maxRecipientsPerBatch ?? 100;
+  assertPositiveInt(maxRecipientsPerBatch, 'config.maxRecipientsPerBatch');
 
   if (recipients.length === 0) {
     throw new Error('Recipients array cannot be empty');
@@ -341,6 +350,8 @@ export async function prepareBatchWeightedDistribution(
  * \`\`\`
  */
 export function createBatches<T>(array: T[], batchSize: number): T[][] {
+  assertPositiveInt(batchSize, 'batchSize');
+
   const batches: T[][] = [];
   
   for (let i = 0; i < array.length; i += batchSize) {

--- a/packages/sdk/src/utils/rpcConnectionOptions.ts
+++ b/packages/sdk/src/utils/rpcConnectionOptions.ts
@@ -1,0 +1,68 @@
+/**
+ * Helpers for safely configuring Stellar RPC / Horizon HTTP connections.
+ *
+ * Plain HTTP is only permitted for local loopback endpoints when the caller
+ * explicitly opts in via `allowHttp: true`.
+ */
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+
+export interface RpcConnectionOptions {
+  /** Opt in to plain HTTP for local loopback RPC/Horizon URLs. Defaults to false. */
+  allowHttp?: boolean;
+}
+
+/**
+ * Returns true when `url` uses plain HTTP against a local loopback host.
+ */
+export function isLoopbackHttpUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== 'http:') {
+    return false;
+  }
+
+  return LOOPBACK_HOSTNAMES.has(parsed.hostname);
+}
+
+/**
+ * Rejects non-loopback plain-HTTP URLs before any network client is created.
+ */
+export function assertSecureRpcUrl(url: string): void {
+  if (url.startsWith('http://') && !isLoopbackHttpUrl(url)) {
+    throw new Error(
+      `Insecure RPC URL rejected: "${url}". Use https:// for remote hosts. ` +
+        'Plain HTTP is only permitted for local development against ' +
+        'http://localhost, http://127.0.0.1, or http://[::1] with allowHttp: true.'
+    );
+  }
+}
+
+/**
+ * Resolves Stellar SDK `{ allowHttp }` server options from a URL and caller config.
+ */
+export function resolveRpcServerOptions(
+  url: string,
+  options: RpcConnectionOptions = {}
+): { allowHttp: boolean } {
+  assertSecureRpcUrl(url);
+
+  const requestedAllowHttp = options.allowHttp ?? false;
+  if (requestedAllowHttp) {
+    if (!isLoopbackHttpUrl(url)) {
+      throw new Error(
+        'allowHttp: true is only permitted for loopback HTTP URLs ' +
+          '(http://localhost, http://127.0.0.1, http://[::1]). ' +
+          `Got: "${url}"`
+      );
+    }
+    return { allowHttp: true };
+  }
+
+  return { allowHttp: false };
+}

--- a/packages/sdk/src/utils/secureRandom.ts
+++ b/packages/sdk/src/utils/secureRandom.ts
@@ -1,0 +1,14 @@
+import { randomBytes } from 'node:crypto';
+
+/**
+ * Returns cryptographically secure random bytes in Node and browser runtimes.
+ */
+export function secureRandomBytes(length: number): Buffer {
+  if (typeof globalThis.crypto?.getRandomValues === 'function') {
+    const bytes = new Uint8Array(length);
+    globalThis.crypto.getRandomValues(bytes);
+    return Buffer.from(bytes);
+  }
+
+  return randomBytes(length);
+}

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -22,7 +22,6 @@ export default defineConfig({
       include: ['src/**/*.ts'],
 
       // Exclude generated bindings, test files, and files with no executable logic.
-      // TODO: remove batchDistribution.ts from this list once its tests are written.
       exclude: [
         'src/generated/**',
         'src/**/__tests__/**',
@@ -33,7 +32,6 @@ export default defineConfig({
         'src/index.ts',                   // pure re-export barrel
         'src/deployer/index.ts',          // pure re-export barrel
         'src/deployer/types.ts',          // TypeScript type definitions only
-        'src/utils/batchDistribution.ts', // TODO: add tests (tracked in backlog)
       ],
 
       // text  → terminal summary on every run


### PR DESCRIPTION
## Summary

Fixes three SDK/web security issues: (#255), (#257), and (#254).

- **#255 — RPC transport security:** Remove unconditional `{ allowHttp: true }` from production code paths. Introduce `resolveRpcServerOptions()` so plain HTTP is only permitted for loopback hosts (`localhost`, `127.0.0.1`, `[::1]`) when callers explicitly pass `allowHttp: true`. Non-loopback `http://` URLs are rejected at construction time with an actionable error. The web app only enables `allowHttp` in non-production builds against loopback URLs.
- **#257 — Batch distribution validation:** Validate `maxRecipientsPerBatch` / `batchSize` as positive integers at public entry points and in `createBatches`. Prevents infinite loops on `0`, silent no-ops on negative values, and overlapping slices from non-integer batch sizes.
- **#254 — CSPRNG for contract deploy salt:** Replace `Math.random()`-based salt generation in `ContractDeployer` with `secureRandomBytes()` (Web Crypto API or Node `crypto.randomBytes`).

## Changes

### SDK (`packages/sdk`)
- New: `utils/rpcConnectionOptions.ts`, `utils/secureRandom.ts`
- Updated: `ContractDeployer`, `GasEstimator`, `batchDistribution`, `DeployerConfig` (`allowHttp?: boolean`)
- Tests: `rpcConnectionOptions.test.ts`, `batchDistribution.test.ts`, plus security/salt cases in `ContractDeployer` tests
- Docs: local HTTP workflow documented in `DEVELOPMENT_GUIDE.md`

### Web app (`apps/web`)
- New: `utils/rpc-connection-options.ts`
- Updated: `stellar.service.ts`, `contract.deployer.ts`, `use-distribution-transaction.ts`

## Test plan

- [x] `createBatches([1,2,3], 0)` throws with clear message
- [x] `createBatches([1,2,3], -1)` throws
- [x] `createBatches([1,2,3], 1.5)` throws
- [x] `prepareBatchEqualDistribution` / `prepareBatchWeightedDistribution` reject invalid `maxRecipientsPerBatch` before any RPC calls
- [x] `ContractDeployer` rejects `http://evil.example/rpc` at construction
- [x] `ContractDeployer` accepts `http://localhost:8000` with `allowHttp: true`
- [x] Two consecutive `randomSalt()` calls produce distinct 32-byte buffers without using `Math.random`
- [ ] Verify production web build uses HTTPS endpoints only (no `allowHttp` in prod)
- [ ] Local dev against `http://localhost:8000` works with SDK `allowHttp: true`

## Closes

- Closes #254
- Closes #255
- Closes #257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to enable HTTP connections for local development RPC servers.
  * Added secure random salt generation for deployments.

* **Bug Fixes**
  * Improved RPC URL security validation to reject insecure HTTP connections for non-local servers by default.

* **Documentation**
  * Added troubleshooting guide for local RPC development setup.

* **Tests**
  * Added comprehensive test coverage for RPC security, batch distribution, and salt generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->