### PR TITLE
feat(sdk): add utility class for subscribing to token balance changes

### DIFF
--- a/packages/sdk/src/__tests__/BalanceWatcher.test.ts
+++ b/packages/sdk/src/__tests__/BalanceWatcher.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BalanceWatcher } from '../utils/BalanceWatcher';
+import type { Stream } from '../generated/payment-stream/src/index';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -11,13 +12,27 @@ vi.mock('@stellar/stellar-sdk', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('@stellar/stellar-sdk');
   return {
     ...actual,
+    rpc: {
+      Server: vi.fn().mockImplementation(() => ({
+        simulateTransaction: mockSimulateTransaction,
+        getNetwork: mockGetNetwork,
+      })),
+      Api: {
+        isSimulationError: vi.fn(
+          (r: Record<string, unknown>) => 'error' in r && r.error !== undefined,
+        ),
+      },
+    },
+    // Keep legacy SorobanRpc alias working too
     SorobanRpc: {
       Server: vi.fn().mockImplementation(() => ({
         simulateTransaction: mockSimulateTransaction,
         getNetwork: mockGetNetwork,
       })),
       Api: {
-        isSimulationError: vi.fn((r: Record<string, unknown>) => 'error' in r && r.error !== undefined),
+        isSimulationError: vi.fn(
+          (r: Record<string, unknown>) => 'error' in r && r.error !== undefined,
+        ),
       },
     },
     TransactionBuilder: vi.fn().mockImplementation(() => ({
@@ -41,159 +56,621 @@ vi.mock('@stellar/stellar-sdk', async () => {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-const RPC_URL = 'https://soroban-testnet.stellar.org';
+const RPC_URL   = 'https://soroban-testnet.stellar.org';
 const PASSPHRASE = 'Test SDF Network ; September 2015';
-const ADDRESS = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
-const TOKEN = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+const ADDRESS   = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+const ADDRESS_B = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+const TOKEN     = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+const TOKEN_B   = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
 
-function makeWatcher(opts?: { networkPassphrase?: string }) {
+const MOCK_STREAM: Pick<Stream, 'sender' | 'recipient' | 'token'> = {
+  sender: ADDRESS,
+  recipient: ADDRESS_B,
+  token: TOKEN,
+};
+
+function makeWatcher(opts?: Partial<ConstructorParameters<typeof BalanceWatcher>[0]>) {
   return new BalanceWatcher({
     rpcUrl: RPC_URL,
-    networkPassphrase: opts?.networkPassphrase ?? PASSPHRASE,
-    pollInterval: 60_000, // long interval so auto-polling doesn't interfere
+    networkPassphrase: PASSPHRASE,
+    pollInterval: 60_000, // long interval — prevents auto-polls interfering
+    ...opts,
   });
 }
 
-function mockSuccess(balance: bigint) {
+/** Wire up the SDK mocks so that fetchBalance(ADDRESS, TOKEN) returns `balance`. */
+function mockBalanceSuccess(balance: bigint) {
   const { scValToNative } = require('@stellar/stellar-sdk');
-  mockSimulateTransaction.mockResolvedValue({
-    result: { retval: {} },
-  });
+  mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
   (scValToNative as ReturnType<typeof vi.fn>).mockReturnValue(balance);
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-describe('BalanceWatcher.fetchBalance', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockGetNetwork.mockResolvedValue({ passphrase: PASSPHRASE });
-  });
+/** Shorthand: manually invoke the private pollBalances method. */
+function poll(watcher: BalanceWatcher): Promise<void> {
+  return (watcher as unknown as { pollBalances(): Promise<void> }).pollBalances();
+}
 
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetNetwork.mockResolvedValue({ passphrase: PASSPHRASE });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ===========================================================================
+// fetchBalance
+// ===========================================================================
+describe('BalanceWatcher.fetchBalance', () => {
   it('returns the balance from a successful simulation', async () => {
-    mockSuccess(1_000_000n);
+    mockBalanceSuccess(1_000_000n);
     const watcher = makeWatcher();
-    const balance = await watcher.fetchBalance(ADDRESS, TOKEN);
-    expect(balance).toBe(1_000_000n);
+    expect(await watcher.fetchBalance(ADDRESS, TOKEN)).toBe(1_000_000n);
   });
 
   it('returns 0n when the contract reports a zero balance', async () => {
-    mockSuccess(0n);
+    mockBalanceSuccess(0n);
     const watcher = makeWatcher();
     expect(await watcher.fetchBalance(ADDRESS, TOKEN)).toBe(0n);
   });
 
-  it('throws when simulation returns an error', async () => {
+  it('returns large i128 values without loss of precision', async () => {
+    const huge = 170_141_183_460_469_231_731_687_303_715_884_105_727n; // i128 max
+    mockBalanceSuccess(huge);
+    const watcher = makeWatcher();
+    expect(await watcher.fetchBalance(ADDRESS, TOKEN)).toBe(huge);
+  });
+
+  it('throws when simulation returns an error response', async () => {
     mockSimulateTransaction.mockResolvedValue({ error: 'HostError: value error' });
     const watcher = makeWatcher();
     await expect(watcher.fetchBalance(ADDRESS, TOKEN)).rejects.toThrow(
-      'Balance simulation failed'
+      'Balance simulation failed',
     );
   });
 
-  it('throws when simulation returns no result', async () => {
-    mockSimulateTransaction.mockResolvedValue({}); // no result field
+  it('throws when simulation returns no result field', async () => {
+    mockSimulateTransaction.mockResolvedValue({});
     const watcher = makeWatcher();
     await expect(watcher.fetchBalance(ADDRESS, TOKEN)).rejects.toThrow(
-      'Balance simulation returned no result'
+      'Balance simulation returned no result',
     );
   });
 
   it('throws when scValToNative returns a non-bigint', async () => {
     const { scValToNative } = require('@stellar/stellar-sdk');
     mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
-    (scValToNative as ReturnType<typeof vi.fn>).mockReturnValue(42); // number, not bigint
+    (scValToNative as ReturnType<typeof vi.fn>).mockReturnValue(42); // number
     const watcher = makeWatcher();
     await expect(watcher.fetchBalance(ADDRESS, TOKEN)).rejects.toThrow(
-      'Unexpected balance type'
+      'Unexpected balance type',
     );
   });
 
-  it('throws when the RPC call itself rejects', async () => {
+  it('propagates network-level RPC rejections', async () => {
     mockSimulateTransaction.mockRejectedValue(new Error('connection refused'));
     const watcher = makeWatcher();
     await expect(watcher.fetchBalance(ADDRESS, TOKEN)).rejects.toThrow(
-      'connection refused'
+      'connection refused',
     );
   });
 
-  it('fetches the network passphrase from RPC when not provided in options', async () => {
-    mockSuccess(500n);
+  it('fetches the network passphrase from RPC when not provided', async () => {
+    mockBalanceSuccess(500n);
     const watcher = new BalanceWatcher({ rpcUrl: RPC_URL, pollInterval: 60_000 });
     await watcher.fetchBalance(ADDRESS, TOKEN);
     expect(mockGetNetwork).toHaveBeenCalledTimes(1);
   });
 
   it('caches the network passphrase after the first fetch', async () => {
-    mockSuccess(500n);
+    mockBalanceSuccess(500n);
     const watcher = new BalanceWatcher({ rpcUrl: RPC_URL, pollInterval: 60_000 });
     await watcher.fetchBalance(ADDRESS, TOKEN);
     await watcher.fetchBalance(ADDRESS, TOKEN);
     expect(mockGetNetwork).toHaveBeenCalledTimes(1);
   });
 
-  it('does not call getNetwork when passphrase is provided', async () => {
-    mockSuccess(100n);
+  it('does not call getNetwork when passphrase is provided in options', async () => {
+    mockBalanceSuccess(100n);
     const watcher = makeWatcher();
     await watcher.fetchBalance(ADDRESS, TOKEN);
     expect(mockGetNetwork).not.toHaveBeenCalled();
   });
 });
 
-describe('BalanceWatcher watch/poll integration', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockGetNetwork.mockResolvedValue({ passphrase: PASSPHRASE });
-  });
-
-  it('calls the callback when balance changes', async () => {
+// ===========================================================================
+// fetchBalances — bulk
+// ===========================================================================
+describe('BalanceWatcher.fetchBalances', () => {
+  it('returns balances for all requested pairs', async () => {
     const { scValToNative } = require('@stellar/stellar-sdk');
     mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
-    (scValToNative as ReturnType<typeof vi.fn>).mockReturnValue(999n);
+    (scValToNative as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(100n)
+      .mockReturnValueOnce(200n);
 
+    const watcher = makeWatcher();
+    const results = await watcher.fetchBalances([
+      { address: ADDRESS,   token: TOKEN },
+      { address: ADDRESS_B, token: TOKEN },
+    ]);
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ address: ADDRESS,   token: TOKEN, balance: 100n });
+    expect(results[1]).toMatchObject({ address: ADDRESS_B, token: TOKEN, balance: 200n });
+  });
+
+  it('captures errors per-pair without aborting the batch', async () => {
+    const { scValToNative } = require('@stellar/stellar-sdk');
+    // First pair succeeds
+    mockSimulateTransaction
+      .mockResolvedValueOnce({ result: { retval: {} } })
+      .mockRejectedValueOnce(new Error('RPC timeout'));
+    (scValToNative as ReturnType<typeof vi.fn>).mockReturnValueOnce(50n);
+
+    const watcher = makeWatcher();
+    const results = await watcher.fetchBalances([
+      { address: ADDRESS,   token: TOKEN },
+      { address: ADDRESS_B, token: TOKEN },
+    ]);
+
+    expect(results[0].balance).toBe(50n);
+    expect(results[0].error).toBeUndefined();
+    expect(results[1].balance).toBeNull();
+    expect(results[1].error?.message).toContain('RPC timeout');
+  });
+
+  it('returns an empty array for an empty input', async () => {
+    const watcher = makeWatcher();
+    expect(await watcher.fetchBalances([])).toEqual([]);
+  });
+
+  it('handles a single pair', async () => {
+    mockBalanceSuccess(999n);
+    const watcher = makeWatcher();
+    const results = await watcher.fetchBalances([{ address: ADDRESS, token: TOKEN }]);
+    expect(results).toHaveLength(1);
+    expect(results[0].balance).toBe(999n);
+  });
+});
+
+// ===========================================================================
+// getLastKnownBalance
+// ===========================================================================
+describe('BalanceWatcher.getLastKnownBalance', () => {
+  it('returns null before any poll has run', () => {
+    const watcher = makeWatcher();
+    watcher.watch(ADDRESS, TOKEN, vi.fn());
+    expect(watcher.getLastKnownBalance(ADDRESS, TOKEN)).toBeNull();
+    watcher.clear();
+  });
+
+  it('returns the cached balance after the first successful poll', async () => {
+    mockBalanceSuccess(777n);
+    const watcher = makeWatcher();
+    watcher.watch(ADDRESS, TOKEN, vi.fn());
+    await poll(watcher);
+    expect(watcher.getLastKnownBalance(ADDRESS, TOKEN)).toBe(777n);
+    watcher.clear();
+  });
+
+  it('returns null for unwatched address/token pairs', () => {
+    const watcher = makeWatcher();
+    expect(watcher.getLastKnownBalance(ADDRESS, TOKEN)).toBeNull();
+  });
+
+  it('returns null after the watcher is cleared', async () => {
+    mockBalanceSuccess(42n);
+    const watcher = makeWatcher();
+    watcher.watch(ADDRESS, TOKEN, vi.fn());
+    await poll(watcher);
+    watcher.clear();
+    expect(watcher.getLastKnownBalance(ADDRESS, TOKEN)).toBeNull();
+  });
+
+  it('reflects the most recent balance after multiple polls', async () => {
+    const { scValToNative } = require('@stellar/stellar-sdk');
+    mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
+    (scValToNative as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(100n)
+      .mockReturnValueOnce(200n);
+
+    const watcher = makeWatcher();
+    watcher.watch(ADDRESS, TOKEN, vi.fn());
+    await poll(watcher);
+    expect(watcher.getLastKnownBalance(ADDRESS, TOKEN)).toBe(100n);
+    await poll(watcher);
+    expect(watcher.getLastKnownBalance(ADDRESS, TOKEN)).toBe(200n);
+    watcher.clear();
+  });
+});
+
+// ===========================================================================
+// watch / unwatch
+// ===========================================================================
+describe('BalanceWatcher.watch', () => {
+  it('calls the callback when balance changes from null to a value', async () => {
+    mockBalanceSuccess(999n);
     const watcher = makeWatcher();
     const cb = vi.fn();
     watcher.watch(ADDRESS, TOKEN, cb);
-
-    // Manually trigger a poll
-    await (watcher as unknown as { pollBalances: () => Promise<void> }).pollBalances();
-
+    await poll(watcher);
     expect(cb).toHaveBeenCalledWith(
-      expect.objectContaining({ address: ADDRESS, token: TOKEN, balance: 999n })
+      expect.objectContaining({ address: ADDRESS, token: TOKEN, balance: 999n }),
     );
     watcher.clear();
   });
 
   it('does not call the callback when balance is unchanged', async () => {
-    const { scValToNative } = require('@stellar/stellar-sdk');
-    mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
-    (scValToNative as ReturnType<typeof vi.fn>).mockReturnValue(100n);
-
+    mockBalanceSuccess(100n);
     const watcher = makeWatcher();
     const cb = vi.fn();
     watcher.watch(ADDRESS, TOKEN, cb);
-
-    const poll = () => (watcher as unknown as { pollBalances: () => Promise<void> }).pollBalances();
-    await poll(); // first poll — balance changes from null → 100n, callback fires
-    await poll(); // second poll — balance unchanged, callback must NOT fire again
-
+    await poll(watcher); // null → 100n, fires
+    await poll(watcher); // 100n → 100n, does NOT fire
     expect(cb).toHaveBeenCalledTimes(1);
     watcher.clear();
   });
 
-  it('unsubscribe removes the callback', async () => {
+  it('calls the callback again when balance changes on a subsequent poll', async () => {
     const { scValToNative } = require('@stellar/stellar-sdk');
     mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
-    (scValToNative as ReturnType<typeof vi.fn>).mockReturnValue(1n);
+    (scValToNative as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(100n)
+      .mockReturnValueOnce(200n);
 
+    const watcher = makeWatcher();
+    const cb = vi.fn();
+    watcher.watch(ADDRESS, TOKEN, cb);
+    await poll(watcher); // 100n
+    await poll(watcher); // 200n
+    expect(cb).toHaveBeenCalledTimes(2);
+    expect(cb).toHaveBeenLastCalledWith(
+      expect.objectContaining({ balance: 200n }),
+    );
+    watcher.clear();
+  });
+
+  it('supports multiple callbacks for the same pair', async () => {
+    mockBalanceSuccess(50n);
+    const watcher = makeWatcher();
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    watcher.watch(ADDRESS, TOKEN, cb1);
+    watcher.watch(ADDRESS, TOKEN, cb2);
+    await poll(watcher);
+    expect(cb1).toHaveBeenCalledTimes(1);
+    expect(cb2).toHaveBeenCalledTimes(1);
+    watcher.clear();
+  });
+
+  it('supports watching different address/token pairs independently', async () => {
+    const { scValToNative } = require('@stellar/stellar-sdk');
+    mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
+    (scValToNative as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(10n)  // ADDRESS / TOKEN
+      .mockReturnValueOnce(20n); // ADDRESS_B / TOKEN
+
+    const watcher = makeWatcher();
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    watcher.watch(ADDRESS, TOKEN, cb1);
+    watcher.watch(ADDRESS_B, TOKEN, cb2);
+    await poll(watcher);
+    expect(cb1).toHaveBeenCalledWith(expect.objectContaining({ balance: 10n }));
+    expect(cb2).toHaveBeenCalledWith(expect.objectContaining({ balance: 20n }));
+    watcher.clear();
+  });
+
+  it('update object includes address, token, balance, and timestamp', async () => {
+    mockBalanceSuccess(123n);
+    const watcher = makeWatcher();
+    const cb = vi.fn();
+    watcher.watch(ADDRESS, TOKEN, cb);
+    await poll(watcher);
+    const update = cb.mock.calls[0][0];
+    expect(update.address).toBe(ADDRESS);
+    expect(update.token).toBe(TOKEN);
+    expect(update.balance).toBe(123n);
+    expect(typeof update.timestamp).toBe('number');
+    expect(update.timestamp).toBeGreaterThan(0);
+    watcher.clear();
+  });
+});
+
+describe('BalanceWatcher.unwatch (via returned unsub fn)', () => {
+  it('unsubscribe removes the specific callback', async () => {
+    mockBalanceSuccess(1n);
     const watcher = makeWatcher();
     const cb = vi.fn();
     const unsub = watcher.watch(ADDRESS, TOKEN, cb);
     unsub();
-
-    await (watcher as unknown as { pollBalances: () => Promise<void> }).pollBalances();
+    await poll(watcher);
     expect(cb).not.toHaveBeenCalled();
+    watcher.clear();
+  });
+
+  it('unsubscribe removes only the targeted callback, leaving others intact', async () => {
+    mockBalanceSuccess(1n);
+    const watcher = makeWatcher();
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    const unsub1 = watcher.watch(ADDRESS, TOKEN, cb1);
+    watcher.watch(ADDRESS, TOKEN, cb2);
+    unsub1();
+    await poll(watcher);
+    expect(cb1).not.toHaveBeenCalled();
+    expect(cb2).toHaveBeenCalledTimes(1);
+    watcher.clear();
+  });
+
+  it('removes the watcher entry when the last callback is unsubscribed', () => {
+    const watcher = makeWatcher();
+    const cb = vi.fn();
+    const unsub = watcher.watch(ADDRESS, TOKEN, cb);
+    expect(watcher.getWatcherCount()).toBe(1);
+    unsub();
+    expect(watcher.getWatcherCount()).toBe(0);
+  });
+
+  it('stops polling when all watchers are unsubscribed', () => {
+    const watcher = makeWatcher();
+    const unsub = watcher.watch(ADDRESS, TOKEN, vi.fn());
+    expect(watcher.isActive()).toBe(true);
+    unsub();
+    expect(watcher.isActive()).toBe(false);
+  });
+
+  it('calling unsub twice does not throw', () => {
+    const watcher = makeWatcher();
+    const unsub = watcher.watch(ADDRESS, TOKEN, vi.fn());
+    expect(() => { unsub(); unsub(); }).not.toThrow();
+    watcher.clear();
+  });
+});
+
+// ===========================================================================
+// watchStream
+// ===========================================================================
+describe('BalanceWatcher.watchStream', () => {
+  it('registers watchers for both sender and recipient', () => {
+    const watcher = makeWatcher();
+    watcher.watchStream(MOCK_STREAM, vi.fn());
+    expect(watcher.getWatcherCount()).toBe(2);
+    watcher.clear();
+  });
+
+  it('notifies callback for sender balance change', async () => {
+    const { scValToNative } = require('@stellar/stellar-sdk');
+    mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
+    (scValToNative as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(100n)  // sender
+      .mockReturnValueOnce(200n); // recipient
+
+    const watcher = makeWatcher();
+    const cb = vi.fn();
+    watcher.watchStream(MOCK_STREAM, cb);
+    await poll(watcher);
+
+    const senderCall = cb.mock.calls.find(([u]) => u.address === ADDRESS);
+    expect(senderCall).toBeDefined();
+    expect(senderCall![0].balance).toBe(100n);
+    watcher.clear();
+  });
+
+  it('notifies callback for recipient balance change', async () => {
+    const { scValToNative } = require('@stellar/stellar-sdk');
+    mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
+    (scValToNative as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(100n)  // sender
+      .mockReturnValueOnce(200n); // recipient
+
+    const watcher = makeWatcher();
+    const cb = vi.fn();
+    watcher.watchStream(MOCK_STREAM, cb);
+    await poll(watcher);
+
+    const recipientCall = cb.mock.calls.find(([u]) => u.address === ADDRESS_B);
+    expect(recipientCall).toBeDefined();
+    expect(recipientCall![0].balance).toBe(200n);
+    watcher.clear();
+  });
+
+  it('unsubscribing removes both sender and recipient watchers', () => {
+    const watcher = makeWatcher();
+    const unsub = watcher.watchStream(MOCK_STREAM, vi.fn());
+    expect(watcher.getWatcherCount()).toBe(2);
+    unsub();
+    expect(watcher.getWatcherCount()).toBe(0);
+  });
+
+  it('unsubscribing stops the polling loop when no other watchers exist', () => {
+    const watcher = makeWatcher();
+    const unsub = watcher.watchStream(MOCK_STREAM, vi.fn());
+    expect(watcher.isActive()).toBe(true);
+    unsub();
+    expect(watcher.isActive()).toBe(false);
+  });
+
+  it('uses stream.token for both sender and recipient subscriptions', async () => {
+    mockBalanceSuccess(1n);
+    const watcher = makeWatcher();
+    const cb = vi.fn();
+    watcher.watchStream(MOCK_STREAM, cb);
+    await poll(watcher);
+    cb.mock.calls.forEach(([update]) => {
+      expect(update.token).toBe(TOKEN);
+    });
+    watcher.clear();
+  });
+});
+
+// ===========================================================================
+// onError callback
+// ===========================================================================
+describe('BalanceWatcher onError option', () => {
+  it('invokes onError when a poll fails instead of console.error', async () => {
+    mockSimulateTransaction.mockRejectedValue(new Error('RPC down'));
+    const onError = vi.fn();
+    const watcher = makeWatcher({ onError });
+    watcher.watch(ADDRESS, TOKEN, vi.fn());
+    await poll(watcher);
+    expect(onError).toHaveBeenCalledWith(
+      expect.any(Error),
+      ADDRESS,
+      TOKEN,
+    );
+    expect(onError.mock.calls[0][0].message).toContain('RPC down');
+    watcher.clear();
+  });
+
+  it('passes the correct address and token to onError', async () => {
+    mockSimulateTransaction.mockRejectedValue(new Error('fail'));
+    const onError = vi.fn();
+    const watcher = makeWatcher({ onError });
+    watcher.watch(ADDRESS_B, TOKEN_B, vi.fn());
+    await poll(watcher);
+    expect(onError).toHaveBeenCalledWith(expect.any(Error), ADDRESS_B, TOKEN_B);
+    watcher.clear();
+  });
+
+  it('does not throw if onError itself throws', async () => {
+    mockSimulateTransaction.mockRejectedValue(new Error('fail'));
+    const watcher = makeWatcher({
+      onError: () => { throw new Error('handler error'); },
+    });
+    watcher.watch(ADDRESS, TOKEN, vi.fn());
+    await expect(poll(watcher)).resolves.not.toThrow();
+    watcher.clear();
+  });
+
+  it('poll errors for one pair do not stop other pairs from being polled', async () => {
+    const { scValToNative } = require('@stellar/stellar-sdk');
+    mockSimulateTransaction
+      .mockRejectedValueOnce(new Error('fail A'))         // ADDRESS / TOKEN fails
+      .mockResolvedValueOnce({ result: { retval: {} } }); // ADDRESS_B / TOKEN succeeds
+    (scValToNative as ReturnType<typeof vi.fn>).mockReturnValue(88n);
+
+    const onError = vi.fn();
+    const cbB = vi.fn();
+    const watcher = makeWatcher({ onError });
+    watcher.watch(ADDRESS, TOKEN, vi.fn());
+    watcher.watch(ADDRESS_B, TOKEN, cbB);
+    await poll(watcher);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledWith(expect.objectContaining({ balance: 88n }));
+    watcher.clear();
+  });
+});
+
+// ===========================================================================
+// Lifecycle — start / stop / clear
+// ===========================================================================
+describe('BalanceWatcher lifecycle', () => {
+  it('isActive() returns false before any watch is registered', () => {
+    const watcher = makeWatcher();
+    expect(watcher.isActive()).toBe(false);
+  });
+
+  it('isActive() returns true after watch() is called', () => {
+    const watcher = makeWatcher();
+    watcher.watch(ADDRESS, TOKEN, vi.fn());
+    expect(watcher.isActive()).toBe(true);
+    watcher.clear();
+  });
+
+  it('isActive() returns false after stop()', () => {
+    const watcher = makeWatcher();
+    watcher.watch(ADDRESS, TOKEN, vi.fn());
+    watcher.stop();
+    expect(watcher.isActive()).toBe(false);
+    watcher.clear();
+  });
+
+  it('start() resumes polling after stop()', async () => {
+    mockBalanceSuccess(1n);
+    const watcher = makeWatcher();
+    watcher.watch(ADDRESS, TOKEN, vi.fn());
+    watcher.stop();
+    expect(watcher.isActive()).toBe(false);
+    watcher.start();
+    expect(watcher.isActive()).toBe(true);
+    watcher.clear();
+  });
+
+  it('calling start() multiple times does not create duplicate intervals', () => {
+    vi.useFakeTimers();
+    const watcher = makeWatcher();
+    watcher.watch(ADDRESS, TOKEN, vi.fn());
+    watcher.start(); // already running from watch()
+    watcher.start(); // should be a no-op
+    // Only one interval should exist — validated via getWatcherCount staying stable
+    expect(watcher.isActive()).toBe(true);
+    watcher.clear();
+  });
+
+  it('clear() removes all watchers', () => {
+    const watcher = makeWatcher();
+    watcher.watch(ADDRESS, TOKEN, vi.fn());
+    watcher.watch(ADDRESS_B, TOKEN, vi.fn());
+    expect(watcher.getWatcherCount()).toBe(2);
+    watcher.clear();
+    expect(watcher.getWatcherCount()).toBe(0);
+  });
+
+  it('clear() stops polling', () => {
+    const watcher = makeWatcher();
+    watcher.watch(ADDRESS, TOKEN, vi.fn());
+    watcher.clear();
+    expect(watcher.isActive()).toBe(false);
+  });
+
+  it('stop() is idempotent — calling twice does not throw', () => {
+    const watcher = makeWatcher();
+    expect(() => { watcher.stop(); watcher.stop(); }).not.toThrow();
+  });
+
+  it('getWatcherCount() reflects active subscriptions accurately', () => {
+    const watcher = makeWatcher();
+    expect(watcher.getWatcherCount()).toBe(0);
+    const unsub1 = watcher.watch(ADDRESS,   TOKEN, vi.fn());
+    const unsub2 = watcher.watch(ADDRESS_B, TOKEN, vi.fn());
+    expect(watcher.getWatcherCount()).toBe(2);
+    unsub1();
+    expect(watcher.getWatcherCount()).toBe(1);
+    unsub2();
+    expect(watcher.getWatcherCount()).toBe(0);
+  });
+
+  it('polling loop triggers callbacks at the configured interval', async () => {
+    vi.useFakeTimers();
+    const { scValToNative } = require('@stellar/stellar-sdk');
+    mockSimulateTransaction.mockResolvedValue({ result: { retval: {} } });
+    (scValToNative as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(1n)
+      .mockReturnValueOnce(2n)
+      .mockReturnValueOnce(3n);
+
+    const watcher = new BalanceWatcher({
+      rpcUrl: RPC_URL,
+      networkPassphrase: PASSPHRASE,
+      pollInterval: 1_000,
+    });
+    const cb = vi.fn();
+    watcher.watch(ADDRESS, TOKEN, cb);
+
+    // Initial poll fires synchronously via start()
+    await vi.runAllTimersAsync();
+    // Advance by two more intervals
+    vi.advanceTimersByTime(2_000);
+    await vi.runAllTimersAsync();
+
+    expect(cb.mock.calls.length).toBeGreaterThanOrEqual(2);
     watcher.clear();
   });
 });

--- a/packages/sdk/src/__tests__/DistributorClient.test.ts
+++ b/packages/sdk/src/__tests__/DistributorClient.test.ts
@@ -10,6 +10,8 @@ const mockTx = (result: unknown = undefined) => ({
   signAndSend: vi.fn(),
 });
 
+const mockTxNone = () => ({ result: undefined, signAndSend: vi.fn() });
+
 const mockContractClient = {
   distribute_equal: vi.fn(),
   distribute_weighted: vi.fn(),

--- a/packages/sdk/src/__tests__/PaymentStreamClient.test.ts
+++ b/packages/sdk/src/__tests__/PaymentStreamClient.test.ts
@@ -12,6 +12,7 @@ const mockTx = (result: unknown = undefined) => ({
   result,
   signAndSend: mockSignAndSend,
 });
+const mockTxNone = () => ({ result: undefined, signAndSend: mockSignAndSend });
 
 const mockContractClient = {
   create_stream: vi.fn(),

--- a/packages/sdk/src/__tests__/mockRpcServer.test.ts
+++ b/packages/sdk/src/__tests__/mockRpcServer.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Unit tests for the mock RPC server (src/test-utils/mockRpcServer.ts).
+ *
+ * These tests verify the mock's own API contract:
+ *  - All scenario helpers set up the expected default responses.
+ *  - resetMockRpcServer() clears call history AND registered return values.
+ *  - Both mock paths (@stellar/stellar-sdk/rpc and @stellar/stellar-sdk) expose
+ *    a Server constructor that returns the shared mock instance.
+ *  - The Api helpers (isSimulationError, isSimulationSuccess, GetTransactionStatus)
+ *    behave exactly as documented.
+ *
+ * Import order matters: mockRpcServer must be imported BEFORE any SDK module so
+ * that Vitest hoists the vi.mock() calls correctly.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createMockRpcServer,
+  resetMockRpcServer,
+  DEFAULT_MOCK_ACCOUNT,
+  DEFAULT_SIMULATION_SUCCESS,
+  DEFAULT_TX_SUCCESS,
+  DEFAULT_SEND_TX_RESPONSE,
+  DEFAULT_NETWORK_INFO,
+  DEFAULT_LATEST_LEDGER,
+  DEFAULT_FEE_STATS,
+} from '../test-utils/mockRpcServer';
+import { Server as RpcServer, Api } from '@stellar/stellar-sdk/rpc';
+import { rpc as StellarRpc, SorobanRpc } from '@stellar/stellar-sdk';
+
+// ---------------------------------------------------------------------------
+// Shared mock instance
+// ---------------------------------------------------------------------------
+const rpc = createMockRpcServer();
+
+beforeEach(() => {
+  resetMockRpcServer();
+});
+
+// ---------------------------------------------------------------------------
+// Module-level vi.mock() integration — Server constructor wiring
+// ---------------------------------------------------------------------------
+describe('module mock wiring', () => {
+  it('@stellar/stellar-sdk/rpc Server constructor returns the mock instance', () => {
+    const server = new RpcServer('https://soroban-testnet.stellar.org');
+    expect(server).toBe(rpc);
+  });
+
+  it('@stellar/stellar-sdk rpc.Server constructor returns the mock instance', () => {
+    const server = new StellarRpc.Server('https://soroban-testnet.stellar.org');
+    expect(server).toBe(rpc);
+  });
+
+  it('@stellar/stellar-sdk SorobanRpc.Server constructor returns the mock instance', () => {
+    const server = new SorobanRpc.Server('https://soroban-testnet.stellar.org');
+    expect(server).toBe(rpc);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Api namespace shape
+// ---------------------------------------------------------------------------
+describe('Api namespace', () => {
+  it('isSimulationError returns true for objects with an error field', () => {
+    expect(Api.isSimulationError({ error: 'HostError' } as any)).toBe(true);
+    expect(Api.isSimulationError({ error: '' } as any)).toBe(true);
+  });
+
+  it('isSimulationError returns false for objects without an error field', () => {
+    expect(Api.isSimulationError({ minResourceFee: '100' } as any)).toBe(false);
+    expect(Api.isSimulationError({} as any)).toBe(false);
+  });
+
+  it('isSimulationSuccess returns true for objects without an error field', () => {
+    expect(Api.isSimulationSuccess({ minResourceFee: '100' } as any)).toBe(true);
+    expect(Api.isSimulationSuccess({} as any)).toBe(true);
+  });
+
+  it('isSimulationSuccess returns false for objects with an error field', () => {
+    expect(Api.isSimulationSuccess({ error: 'bad' } as any)).toBe(false);
+  });
+
+  it('GetTransactionStatus has correct string constants', () => {
+    expect(Api.GetTransactionStatus.SUCCESS).toBe('SUCCESS');
+    expect(Api.GetTransactionStatus.FAILED).toBe('FAILED');
+    expect(Api.GetTransactionStatus.PENDING).toBe('PENDING');
+    expect(Api.GetTransactionStatus.NOT_FOUND).toBe('NOT_FOUND');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SorobanRpc namespace (umbrella package alias)
+// ---------------------------------------------------------------------------
+describe('SorobanRpc namespace from @stellar/stellar-sdk', () => {
+  it('GetTransactionStatus constants are correct', () => {
+    expect(SorobanRpc.GetTransactionStatus.SUCCESS).toBe('SUCCESS');
+    expect(SorobanRpc.GetTransactionStatus.FAILED).toBe('FAILED');
+    expect(SorobanRpc.GetTransactionStatus.NOT_FOUND).toBe('NOT_FOUND');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resetMockRpcServer
+// ---------------------------------------------------------------------------
+describe('resetMockRpcServer', () => {
+  it('clears registered return values so subsequent calls return undefined', async () => {
+    rpc.getAccount.mockResolvedValue(DEFAULT_MOCK_ACCOUNT);
+    resetMockRpcServer();
+    // After reset the mock has no return value configured → resolves to undefined
+    const result = await rpc.getAccount('G...');
+    expect(result).toBeUndefined();
+  });
+
+  it('clears call history', async () => {
+    rpc.simulateTransaction.mockResolvedValue(DEFAULT_SIMULATION_SUCCESS);
+    await rpc.simulateTransaction({} as any);
+    expect(rpc.simulateTransaction).toHaveBeenCalledTimes(1);
+
+    resetMockRpcServer();
+    expect(rpc.simulateTransaction).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not affect mock functions registered after the reset', async () => {
+    resetMockRpcServer();
+    rpc.getNetwork.mockResolvedValue(DEFAULT_NETWORK_INFO);
+    const info = await rpc.getNetwork();
+    expect(info).toEqual(DEFAULT_NETWORK_INFO);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scenarios.success
+// ---------------------------------------------------------------------------
+describe('scenarios.success', () => {
+  beforeEach(() => rpc.scenarios.success());
+
+  it('getAccount resolves with the default mock account', async () => {
+    const account = await rpc.getAccount(DEFAULT_MOCK_ACCOUNT.id);
+    expect(account).toEqual(DEFAULT_MOCK_ACCOUNT);
+  });
+
+  it('simulateTransaction resolves with the default simulation response', async () => {
+    const sim = await rpc.simulateTransaction({} as any);
+    expect(sim).toEqual(DEFAULT_SIMULATION_SUCCESS);
+  });
+
+  it('sendTransaction resolves with the default send response', async () => {
+    const send = await rpc.sendTransaction({} as any);
+    expect(send).toEqual(DEFAULT_SEND_TX_RESPONSE);
+  });
+
+  it('getTransaction resolves with SUCCESS status', async () => {
+    const tx = await rpc.getTransaction('hash');
+    expect(tx.status).toBe('SUCCESS');
+    if (tx.status === 'SUCCESS') {
+      expect(tx.ledger).toBe(DEFAULT_TX_SUCCESS.ledger);
+    }
+  });
+
+  it('getNetwork resolves with the default network info', async () => {
+    const network = await rpc.getNetwork();
+    expect(network).toEqual(DEFAULT_NETWORK_INFO);
+  });
+
+  it('getLatestLedger resolves with the default ledger', async () => {
+    const ledger = await rpc.getLatestLedger();
+    expect(ledger).toEqual(DEFAULT_LATEST_LEDGER);
+  });
+
+  it('getFeeStats resolves with the default fee stats', async () => {
+    const stats = await rpc.getFeeStats();
+    expect(stats).toEqual(DEFAULT_FEE_STATS);
+  });
+
+  it('getEvents resolves with an empty event list', async () => {
+    const events = await rpc.getEvents({});
+    expect(events.events).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scenarios.pendingThenSuccess
+// ---------------------------------------------------------------------------
+describe('scenarios.pendingThenSuccess', () => {
+  it('first call returns PENDING, second returns SUCCESS', async () => {
+    rpc.scenarios.pendingThenSuccess({ ledger: 789 });
+
+    const first = await rpc.getTransaction('hash');
+    expect(first.status).toBe('PENDING');
+
+    const second = await rpc.getTransaction('hash');
+    expect(second.status).toBe('SUCCESS');
+    if (second.status === 'SUCCESS') {
+      expect(second.ledger).toBe(789);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scenarios.notFoundThenSuccess
+// ---------------------------------------------------------------------------
+describe('scenarios.notFoundThenSuccess', () => {
+  it('first call returns NOT_FOUND, second returns SUCCESS', async () => {
+    rpc.scenarios.notFoundThenSuccess({ ledger: 999 });
+
+    const first = await rpc.getTransaction('hash');
+    expect(first.status).toBe('NOT_FOUND');
+
+    const second = await rpc.getTransaction('hash');
+    expect(second.status).toBe('SUCCESS');
+    if (second.status === 'SUCCESS') {
+      expect(second.ledger).toBe(999);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scenarios.transactionFailed
+// ---------------------------------------------------------------------------
+describe('scenarios.transactionFailed', () => {
+  it('getTransaction always resolves with FAILED status', async () => {
+    rpc.scenarios.transactionFailed({ ledger: 42 });
+    const tx = await rpc.getTransaction('hash');
+    expect(tx.status).toBe('FAILED');
+    if (tx.status === 'FAILED') {
+      expect(tx.ledger).toBe(42);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scenarios.simulationError
+// ---------------------------------------------------------------------------
+describe('scenarios.simulationError', () => {
+  it('simulateTransaction resolves with an error-shaped object', async () => {
+    rpc.scenarios.simulationError('HostError: bad value');
+    const sim = await rpc.simulateTransaction({} as any);
+    expect(Api.isSimulationError(sim as any)).toBe(true);
+    expect((sim as any).error).toBe('HostError: bad value');
+  });
+
+  it('uses a default message when none is provided', async () => {
+    rpc.scenarios.simulationError();
+    const sim = await rpc.simulateTransaction({} as any);
+    expect((sim as any).error).toContain('HostError');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scenarios.simulationNetworkError
+// ---------------------------------------------------------------------------
+describe('scenarios.simulationNetworkError', () => {
+  it('simulateTransaction rejects with the provided message', async () => {
+    rpc.scenarios.simulationNetworkError('ECONNREFUSED');
+    await expect(rpc.simulateTransaction({} as any)).rejects.toThrow('ECONNREFUSED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scenarios.sendTransactionError
+// ---------------------------------------------------------------------------
+describe('scenarios.sendTransactionError', () => {
+  it('sendTransaction resolves with ERROR status', async () => {
+    rpc.scenarios.sendTransactionError();
+    const send = await rpc.sendTransaction({} as any);
+    expect(send.status).toBe('ERROR');
+  });
+
+  it('errorResult.toXDR returns the provided XDR string', async () => {
+    rpc.scenarios.sendTransactionError('customXDR==');
+    const send = await rpc.sendTransaction({} as any);
+    expect(send.errorResult?.toXDR('base64')).toBe('customXDR==');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scenarios.accountNotFound
+// ---------------------------------------------------------------------------
+describe('scenarios.accountNotFound', () => {
+  it('getAccount rejects with a descriptive error', async () => {
+    rpc.scenarios.accountNotFound('GABC...');
+    await expect(rpc.getAccount('GABC...')).rejects.toThrow('Account not found: GABC...');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scenarios.networkError
+// ---------------------------------------------------------------------------
+describe('scenarios.networkError', () => {
+  it('getNetwork rejects with the provided message', async () => {
+    rpc.scenarios.networkError('connection refused');
+    await expect(rpc.getNetwork()).rejects.toThrow('connection refused');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scenarios.highCongestionFeeStats
+// ---------------------------------------------------------------------------
+describe('scenarios.highCongestionFeeStats', () => {
+  it('getFeeStats resolves with high-congestion fee data', async () => {
+    rpc.scenarios.highCongestionFeeStats();
+    const stats = await rpc.getFeeStats();
+    const p99 = Number(stats.inclusionFee?.p99);
+    expect(p99).toBeGreaterThan(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scenarios.contractEvents
+// ---------------------------------------------------------------------------
+describe('scenarios.contractEvents', () => {
+  it('getEvents resolves with the provided events', async () => {
+    const events = [
+      { pagingToken: 'tok-1', topic: ['StreamCreated'], value: { stream_id: 1n } },
+      { pagingToken: 'tok-2', topic: ['StreamDeposit'],  value: { stream_id: 1n, amount: 100n } },
+    ];
+    rpc.scenarios.contractEvents(events, 555);
+    const response = await rpc.getEvents({});
+    expect(response.events).toHaveLength(2);
+    expect(response.latestLedger).toBe(555);
+    expect(response.events[0].pagingToken).toBe('tok-1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scenarios.getEventsError
+// ---------------------------------------------------------------------------
+describe('scenarios.getEventsError', () => {
+  it('getEvents rejects with the provided message', async () => {
+    rpc.scenarios.getEventsError('RPC timeout');
+    await expect(rpc.getEvents({})).rejects.toThrow('RPC timeout');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-test mock overrides on top of a scenario
+// ---------------------------------------------------------------------------
+describe('per-test overrides on top of scenarios', () => {
+  it('mockResolvedValueOnce overrides work after scenarios.success()', async () => {
+    rpc.scenarios.success();
+    // Override just one call
+    rpc.getTransaction.mockResolvedValueOnce({ status: 'PENDING' });
+    // First call → PENDING override
+    expect((await rpc.getTransaction('h')).status).toBe('PENDING');
+    // Second call → falls back to scenario default (SUCCESS)
+    expect((await rpc.getTransaction('h')).status).toBe('SUCCESS');
+  });
+
+  it('calling scenarios.success() after reset reapplies defaults', async () => {
+    rpc.scenarios.simulationError('test error');
+    // Confirm it's in error mode
+    expect(Api.isSimulationError((await rpc.simulateTransaction({} as any)) as any)).toBe(true);
+
+    resetMockRpcServer();
+    rpc.scenarios.success();
+    // Should be back to success mode
+    expect(Api.isSimulationError((await rpc.simulateTransaction({} as any)) as any)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Verify vi.fn() identity — mock functions are real Vitest mock functions
+// ---------------------------------------------------------------------------
+describe('mock function identity', () => {
+  it('all RPC methods expose toHaveBeenCalled matchers', () => {
+    const methods = [
+      'getAccount',
+      'simulateTransaction',
+      'sendTransaction',
+      'getTransaction',
+      'getNetwork',
+      'getLatestLedger',
+      'getLedger',
+      'getFeeStats',
+      'getEvents',
+    ] as const;
+
+    for (const method of methods) {
+      expect(vi.isMockFunction(rpc[method])).toBe(true);
+    }
+  });
+});

--- a/packages/sdk/src/test-utils/mockRpcServer.ts
+++ b/packages/sdk/src/test-utils/mockRpcServer.ts
@@ -1,45 +1,548 @@
+/**
+ * Mock RPC Server for SDK Unit Tests
+ *
+ * Provides a reusable, fully-typed mock of the Stellar Soroban RPC server so
+ * unit tests never make real network calls. The mock covers every RPC method
+ * used by the SDK and exposes convenience helpers for common test scenarios.
+ *
+ * ## Usage
+ *
+ * Import this file **once** in each test file that needs to intercept Soroban
+ * RPC calls. The `vi.mock(...)` calls at the bottom of this module are hoisted
+ * by Vitest and intercept both import paths used across the SDK:
+ *
+ *   - `@stellar/stellar-sdk/rpc`   – ContractDeployer, GasEstimator, soroban-transaction-helper
+ *   - `@stellar/stellar-sdk`       – BalanceWatcher (uses `rpc.Server` sub-namespace)
+ *
+ * ```ts
+ * // In your test file:
+ * import { createMockRpcServer, resetMockRpcServer } from '../test-utils/mockRpcServer';
+ *
+ * const rpc = createMockRpcServer();
+ *
+ * beforeEach(() => resetMockRpcServer());
+ *
+ * it('succeeds on a happy-path simulation', async () => {
+ *   rpc.scenarios.simulationSuccess();
+ *   // ... exercise the code under test
+ * });
+ * ```
+ *
+ * ## Design notes
+ *
+ * - All mock functions are `vi.fn()` instances so callers can add per-test
+ *   `.mockResolvedValueOnce(...)` overrides on top of scenario defaults.
+ * - `resetMockRpcServer()` calls `mockReset()` on every vi.fn(), clearing both
+ *   call history and any registered return values so tests start clean.
+ * - The `Api` namespace mirrors the real SDK shape so code that calls
+ *   `Api.isSimulationError(r)` or inspects `Api.GetTransactionStatus` works
+ *   unchanged.
+ */
+
 import { vi } from 'vitest';
 
-const mock = {
-  getAccount: vi.fn(),
-  simulateTransaction: vi.fn(),
-  sendTransaction: vi.fn(),
-  getTransaction: vi.fn(),
-  getNetwork: vi.fn(),
+// ---------------------------------------------------------------------------
+// Type helpers — these mirror the relevant parts of the real Stellar SDK API
+// without importing the SDK itself (which would create a circular dependency
+// with the mocked module).
+// ---------------------------------------------------------------------------
 
-  mockSuccess() {
-    this.simulateTransaction.mockResolvedValue({ result: {} });
-    this.sendTransaction.mockResolvedValue({ hash: 'tx123' });
-    this.getTransaction.mockResolvedValue({ status: 'SUCCESS', ledger: 12345 });
-  },
+/** Minimal shape of a successful simulation response. */
+export interface MockSimulationSuccess {
+  minResourceFee: string;
+  transactionData?: string | object;
+  result?: { retval?: unknown };
+  results?: unknown[];
+}
 
-  mockPendingThenSuccess() {
-    this.getTransaction
-      .mockResolvedValueOnce({ status: 'PENDING' })
-      .mockResolvedValueOnce({ status: 'SUCCESS', ledger: 123 });
-  },
+/** Minimal shape of a failed simulation response. */
+export interface MockSimulationError {
+  error: string;
+}
 
-  mockFailure() {
-    this.getTransaction.mockResolvedValue({ status: 'FAILED', ledger: 123 });
-  },
+/** Minimal shape of a successful getTransaction response. */
+export interface MockGetTransactionSuccess {
+  status: 'SUCCESS';
+  ledger: number;
+  resultXdr?: string;
+  feeCharged?: string;
+}
 
-  mockTimeout() {
-    this.simulateTransaction.mockRejectedValue(new Error('timeout'));
-  },
+/** Minimal shape of a failed getTransaction response. */
+export interface MockGetTransactionFailed {
+  status: 'FAILED';
+  ledger: number;
+  resultXdr?: string;
+}
 
-  mockMalformed() {
-    this.simulateTransaction.mockResolvedValue({});
+/** Minimal shape of a pending / not-found getTransaction response. */
+export interface MockGetTransactionPending {
+  status: 'PENDING' | 'NOT_FOUND';
+}
+
+export type MockGetTransactionResponse =
+  | MockGetTransactionSuccess
+  | MockGetTransactionFailed
+  | MockGetTransactionPending;
+
+/** Minimal shape of a sendTransaction response. */
+export interface MockSendTransactionResponse {
+  status: 'PENDING' | 'ERROR' | 'DUPLICATE' | 'TRY_AGAIN_LATER';
+  hash: string;
+  errorResult?: { toXDR: (fmt: string) => string } | null;
+}
+
+/** Minimal shape of a getAccount / AccountRecord response. */
+export interface MockAccount {
+  id: string;
+  sequenceNumber: () => string;
+}
+
+/** Minimal shape of a getNetwork response. */
+export interface MockNetworkInfo {
+  passphrase: string;
+  protocolVersion?: string;
+}
+
+/** Minimal shape of a getLatestLedger response. */
+export interface MockLatestLedger {
+  id: string;
+  sequence: number | string;
+  protocolVersion: string;
+}
+
+/** Minimal shape of a getLedger response. */
+export interface MockLedgerInfo {
+  baseFeeInStroops?: string | number;
+  sequence?: number | string;
+}
+
+/** Minimal shape of a getFeeStats response. */
+export interface MockFeeStats {
+  inclusionFee?: {
+    p50?: string | number;
+    p90?: string | number;
+    p95?: string | number;
+    p99?: string | number;
+    transactionCount?: string | number;
+  };
+  sorobanInclusionFee?: {
+    p50?: string | number;
+    p90?: string | number;
+    p95?: string | number;
+    p99?: string | number;
+    transactionCount?: string | number;
+  };
+}
+
+/** Minimal shape of a getEvents response. */
+export interface MockGetEventsResponse {
+  events: Array<{
+    pagingToken: string;
+    topic: unknown[];
+    value: unknown;
+    contractId?: string;
+    id?: string;
+    ledger?: number;
+    type?: string;
+  }>;
+  latestLedger: number;
+}
+
+// ---------------------------------------------------------------------------
+// Default fixture values
+// ---------------------------------------------------------------------------
+
+/** Default passphrase for Stellar testnet. */
+export const DEFAULT_NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+
+/** A plausible testnet RPC URL used in fixture data. */
+export const DEFAULT_RPC_URL = 'https://soroban-testnet.stellar.org';
+
+/** A valid G-address usable as a default deployer / sender. */
+export const DEFAULT_ADDRESS = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+
+/** A default mock account object. */
+export const DEFAULT_MOCK_ACCOUNT: MockAccount = {
+  id: DEFAULT_ADDRESS,
+  sequenceNumber: () => '100',
+};
+
+/** Default simulation success response with a 1 000-stroop resource fee. */
+export const DEFAULT_SIMULATION_SUCCESS: MockSimulationSuccess = {
+  minResourceFee: '1000',
+  transactionData: 'AAAAAQAAAAA=',
+  result: { retval: undefined },
+  results: [],
+};
+
+/** Default getTransaction success response. */
+export const DEFAULT_TX_SUCCESS: MockGetTransactionSuccess = {
+  status: 'SUCCESS',
+  ledger: 12345,
+  feeCharged: '200',
+};
+
+/** Default sendTransaction response (accepted, waiting to be included). */
+export const DEFAULT_SEND_TX_RESPONSE: MockSendTransactionResponse = {
+  status: 'PENDING',
+  hash: 'mocktxhash1234567890abcdef',
+};
+
+/** Default network info. */
+export const DEFAULT_NETWORK_INFO: MockNetworkInfo = {
+  passphrase: DEFAULT_NETWORK_PASSPHRASE,
+  protocolVersion: '21',
+};
+
+/** Default latest ledger response. */
+export const DEFAULT_LATEST_LEDGER: MockLatestLedger = {
+  id: 'ledger-id-0',
+  sequence: 100,
+  protocolVersion: '21',
+};
+
+/** Default fee stats — low-congestion baseline. */
+export const DEFAULT_FEE_STATS: MockFeeStats = {
+  inclusionFee: {
+    p50: '100',
+    p90: '120',
+    p95: '140',
+    p99: '200',
+    transactionCount: '5',
   },
 };
 
+// ---------------------------------------------------------------------------
+// Core mock object
+// ---------------------------------------------------------------------------
+
+/**
+ * The single shared mock RPC server instance used across all tests in a file.
+ * Individual vi.fn() mocks can be overridden per-test; call `resetMockRpcServer()`
+ * in beforeEach to restore a clean state.
+ */
+const mock = {
+  // ── Core RPC methods ────────────────────────────────────────────────────
+  /** Fetch account details (sequence number, balances, etc.). */
+  getAccount: vi.fn<[string], Promise<MockAccount>>(),
+
+  /** Simulate a Soroban transaction to get fee/resource estimates. */
+  simulateTransaction: vi.fn<[unknown], Promise<MockSimulationSuccess | MockSimulationError>>(),
+
+  /** Submit a signed transaction to the network. */
+  sendTransaction: vi.fn<[unknown], Promise<MockSendTransactionResponse>>(),
+
+  /** Poll for the result of a submitted transaction. */
+  getTransaction: vi.fn<[string], Promise<MockGetTransactionResponse>>(),
+
+  /** Retrieve the network passphrase and protocol version. */
+  getNetwork: vi.fn<[], Promise<MockNetworkInfo>>(),
+
+  /** Fetch the latest closed ledger metadata. */
+  getLatestLedger: vi.fn<[], Promise<MockLatestLedger>>(),
+
+  /** Fetch metadata for a specific ledger by sequence number. */
+  getLedger: vi.fn<[{ sequence: number }], Promise<MockLedgerInfo>>(),
+
+  /** Fetch fee statistics from recent ledgers. */
+  getFeeStats: vi.fn<[], Promise<MockFeeStats>>(),
+
+  /** Fetch contract events with optional filters and pagination. */
+  getEvents: vi.fn<[unknown], Promise<MockGetEventsResponse>>(),
+
+  // ── Scenario helpers ────────────────────────────────────────────────────
+  /**
+   * Pre-configured scenario helpers that wire up the most common test
+   * situations in a single call. Each helper can be further customised with
+   * per-test `.mockResolvedValueOnce(...)` additions on individual mock fns.
+   */
+  scenarios: {
+    /**
+     * Standard happy-path: account loads, simulation succeeds, transaction
+     * is sent and confirmed successfully in a single poll.
+     */
+    success(overrides?: {
+      account?: MockAccount;
+      simulation?: MockSimulationSuccess;
+      sendTx?: Partial<MockSendTransactionResponse>;
+      getTx?: MockGetTransactionSuccess;
+    }): void {
+      mock.getAccount.mockResolvedValue(overrides?.account ?? DEFAULT_MOCK_ACCOUNT);
+      mock.simulateTransaction.mockResolvedValue(
+        overrides?.simulation ?? DEFAULT_SIMULATION_SUCCESS,
+      );
+      mock.sendTransaction.mockResolvedValue({
+        ...DEFAULT_SEND_TX_RESPONSE,
+        ...overrides?.sendTx,
+      });
+      mock.getTransaction.mockResolvedValue(overrides?.getTx ?? DEFAULT_TX_SUCCESS);
+      mock.getNetwork.mockResolvedValue(DEFAULT_NETWORK_INFO);
+      mock.getLatestLedger.mockResolvedValue(DEFAULT_LATEST_LEDGER);
+      mock.getFeeStats.mockResolvedValue(DEFAULT_FEE_STATS);
+      mock.getEvents.mockResolvedValue({ events: [], latestLedger: 100 });
+    },
+
+    /**
+     * Transaction enters a PENDING state on the first poll, then succeeds
+     * on the second poll. Useful for testing polling logic.
+     */
+    pendingThenSuccess(opts?: { ledger?: number }): void {
+      mock.scenarios.success();
+      mock.getTransaction
+        .mockReset()
+        .mockResolvedValueOnce({ status: 'PENDING' } satisfies MockGetTransactionPending)
+        .mockResolvedValueOnce({
+          status: 'SUCCESS',
+          ledger: opts?.ledger ?? 123,
+          feeCharged: '200',
+        } satisfies MockGetTransactionSuccess);
+    },
+
+    /**
+     * Transaction is NOT_FOUND on the first poll (not yet propagated), then
+     * succeeds. Exercises the "not found" retry path in waitForTransaction.
+     */
+    notFoundThenSuccess(opts?: { ledger?: number }): void {
+      mock.scenarios.success();
+      mock.getTransaction
+        .mockReset()
+        .mockResolvedValueOnce({ status: 'NOT_FOUND' } satisfies MockGetTransactionPending)
+        .mockResolvedValueOnce({
+          status: 'SUCCESS',
+          ledger: opts?.ledger ?? 456,
+          feeCharged: '200',
+        } satisfies MockGetTransactionSuccess);
+    },
+
+    /**
+     * Transaction reaches FAILED status on chain.
+     */
+    transactionFailed(opts?: { ledger?: number }): void {
+      mock.scenarios.success();
+      mock.getTransaction.mockReset().mockResolvedValue({
+        status: 'FAILED',
+        ledger: opts?.ledger ?? 123,
+      } satisfies MockGetTransactionFailed);
+    },
+
+    /**
+     * Simulation returns a contract/host error response (not a thrown exception).
+     * Matches what `Api.isSimulationError()` returns `true` for.
+     */
+    simulationError(errorMessage = 'HostError: Value error'): void {
+      mock.simulateTransaction.mockResolvedValue({
+        error: errorMessage,
+      } satisfies MockSimulationError);
+    },
+
+    /**
+     * Simulation throws a network-level exception (e.g. ECONNREFUSED).
+     * Different from a simulation *error response* — this is a thrown Error.
+     */
+    simulationNetworkError(message = 'Network error: connection refused'): void {
+      mock.simulateTransaction.mockRejectedValue(new Error(message));
+    },
+
+    /**
+     * sendTransaction returns an ERROR status (transaction rejected at submission).
+     */
+    sendTransactionError(errorXdr = 'AAAAAAAAAGT////7AAAAAA=='): void {
+      mock.scenarios.success();
+      mock.sendTransaction.mockReset().mockResolvedValue({
+        status: 'ERROR',
+        hash: '',
+        errorResult: { toXDR: () => errorXdr },
+      } satisfies MockSendTransactionResponse);
+    },
+
+    /**
+     * getAccount throws — simulates a funded-account-not-found scenario.
+     */
+    accountNotFound(address = DEFAULT_ADDRESS): void {
+      mock.getAccount.mockRejectedValue(
+        new Error(`Account not found: ${address}`),
+      );
+    },
+
+    /**
+     * getNetwork throws — simulates an RPC connectivity issue during
+     * network passphrase auto-detection.
+     */
+    networkError(message = 'getNetwork failed: connection refused'): void {
+      mock.getNetwork.mockRejectedValue(new Error(message));
+    },
+
+    /**
+     * High-congestion fee stats — p95 is well above base fee thresholds,
+     * causing GasEstimator to choose a higher buffer multiplier.
+     */
+    highCongestionFeeStats(): void {
+      mock.getFeeStats.mockResolvedValue({
+        inclusionFee: {
+          p50: '200',
+          p90: '450',
+          p95: '700',
+          p99: '1200',
+          transactionCount: '520',
+        },
+      } satisfies MockFeeStats);
+    },
+
+    /**
+     * getEvents returns a list of raw contract events. Consumers filter by
+     * stream ID / contract ID themselves, so raw events are passed through.
+     *
+     * @param events - Raw event objects to return.
+     * @param latestLedger - Latest closed ledger (default: 1000).
+     */
+    contractEvents(
+      events: MockGetEventsResponse['events'],
+      latestLedger = 1000,
+    ): void {
+      mock.getEvents.mockResolvedValue({ events, latestLedger });
+    },
+
+    /**
+     * getEvents throws — simulates an RPC failure during event fetching.
+     */
+    getEventsError(message = 'getEvents RPC error'): void {
+      mock.getEvents.mockRejectedValue(new Error(message));
+    },
+  },
+} as const;
+
+export type MockRpcServer = typeof mock;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the shared mock RPC server instance.
+ *
+ * The returned object exposes all mock functions directly so tests can add
+ * per-test overrides, e.g.:
+ *
+ * ```ts
+ * const rpc = createMockRpcServer();
+ * rpc.getTransaction.mockResolvedValueOnce({ status: 'PENDING' });
+ * ```
+ */
+export function createMockRpcServer(): MockRpcServer {
+  return mock;
+}
+
+/**
+ * Resets all mock functions — clears call history **and** registered return
+ * values. Call this in `beforeEach` to guarantee test isolation.
+ *
+ * ```ts
+ * beforeEach(() => resetMockRpcServer());
+ * ```
+ */
+export function resetMockRpcServer(): void {
+  (Object.values(mock) as unknown[]).forEach((value) => {
+    if (value !== null && typeof value === 'object' && !('scenarios' in (value as object))) {
+      const fn = value as { mockReset?: () => void };
+      if (typeof fn.mockReset === 'function') {
+        fn.mockReset();
+      }
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Module-level vi.mock() calls
+//
+// Vitest hoists vi.mock() to the top of the compiled test file, so importing
+// this module is enough to intercept all RPC calls — no manual setup needed.
+//
+// Two paths are mocked:
+//  1. `@stellar/stellar-sdk/rpc`  — used by ContractDeployer, GasEstimator,
+//     soroban-transaction-helper, and transactions.ts (via SorobanRpc alias).
+//  2. `@stellar/stellar-sdk`      — used by BalanceWatcher (rpc.Server) and
+//     streamHistory (StellarSdk.rpc.Server).
+// ---------------------------------------------------------------------------
+
+/**
+ * Mock for `@stellar/stellar-sdk/rpc`.
+ *
+ * Covers imports of the form:
+ *   import { Server, Api } from '@stellar/stellar-sdk/rpc';
+ */
 vi.mock('@stellar/stellar-sdk/rpc', () => ({
   Server: vi.fn(() => mock),
   Api: {
-    isSimulationError: (r: Record<string, unknown>) => r?.error !== undefined,
-    isSimulationSuccess: (r: Record<string, unknown>) => r?.error === undefined,
-    GetTransactionStatus: { NOT_FOUND: 'NOT_FOUND', SUCCESS: 'SUCCESS', FAILED: 'FAILED' },
+    /**
+     * Returns true when the simulation response has a top-level `error` field.
+     * Mirrors the real SDK behaviour.
+     */
+    isSimulationError: (r: Record<string, unknown>): boolean =>
+      r !== null && typeof r === 'object' && r['error'] !== undefined,
+
+    /**
+     * Returns true when the simulation response does NOT have a top-level
+     * `error` field. Mirrors the real SDK behaviour.
+     */
+    isSimulationSuccess: (r: Record<string, unknown>): boolean =>
+      r !== null && typeof r === 'object' && r['error'] === undefined,
+
+    /** GetTransactionStatus enum values used throughout the SDK. */
+    GetTransactionStatus: {
+      NOT_FOUND: 'NOT_FOUND',
+      PENDING: 'PENDING',
+      SUCCESS: 'SUCCESS',
+      FAILED: 'FAILED',
+    } as const,
   },
 }));
 
-export function createMockRpcServer() { return mock; }
-export function resetMockRpcServer() { Object.values(mock).forEach((fn) => { if (typeof fn === 'function' && 'mockReset' in fn) fn.mockReset(); }); }
+/**
+ * Mock for `@stellar/stellar-sdk` (the umbrella package).
+ *
+ * Only the `rpc` sub-namespace and the `SorobanRpc` alias are replaced here;
+ * everything else (`Keypair`, `Networks`, `xdr`, `Address`, etc.) is kept as
+ * the real implementation so XDR encoding / key derivation works correctly in
+ * tests that need it.
+ *
+ * Covers imports of the form:
+ *   import * as StellarSdk from '@stellar/stellar-sdk';
+ *   import { SorobanRpc }   from '@stellar/stellar-sdk';
+ */
+vi.mock('@stellar/stellar-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@stellar/stellar-sdk')>();
+
+  const MockServer = vi.fn(() => mock);
+
+  const mockApi = {
+    isSimulationError: (r: Record<string, unknown>): boolean =>
+      r !== null && typeof r === 'object' && r['error'] !== undefined,
+    isSimulationSuccess: (r: Record<string, unknown>): boolean =>
+      r !== null && typeof r === 'object' && r['error'] === undefined,
+    GetTransactionStatus: {
+      NOT_FOUND: 'NOT_FOUND',
+      PENDING: 'PENDING',
+      SUCCESS: 'SUCCESS',
+      FAILED: 'FAILED',
+    } as const,
+  };
+
+  return {
+    ...actual,
+    // The `rpc` named export (used by streamHistory and BalanceWatcher)
+    rpc: {
+      ...(actual.rpc ?? {}),
+      Server: MockServer,
+      Api: mockApi,
+      EventFilter: actual.rpc?.EventFilter,
+    },
+    // Legacy `SorobanRpc` alias (used by transactions.ts)
+    SorobanRpc: {
+      ...(actual.SorobanRpc ?? {}),
+      Server: MockServer,
+      Api: mockApi,
+      GetTransactionStatus: mockApi.GetTransactionStatus,
+    },
+  };
+});

--- a/packages/sdk/src/utils/BalanceWatcher.ts
+++ b/packages/sdk/src/utils/BalanceWatcher.ts
@@ -1,8 +1,15 @@
 /**
  * BalanceWatcher - Utility class for monitoring token balance changes
- * 
- * Provides a helper class to subscribe to balance changes for specific tokens/addresses
- * involved in streams using RPC polling or event subscription.
+ *
+ * Subscribes to balance changes for specific tokens/addresses involved in
+ * payment streams using RPC polling. Supports:
+ *
+ *  - Per-address/token subscriptions via `watch()`
+ *  - Stream-level subscriptions via `watchStream()` (watches sender + recipient)
+ *  - Bulk balance fetching via `fetchBalances()`
+ *  - Last-known balance cache via `getLastKnownBalance()`
+ *  - Per-instance error callbacks via `onError` option
+ *  - Clean lifecycle management: `start()`, `stop()`, `clear()`
  */
 
 import {
@@ -13,36 +20,119 @@ import {
   scValToNative,
   Address,
 } from "@stellar/stellar-sdk";
+import type { Stream } from "../generated/payment-stream/src/index.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
 
 export interface BalanceWatcherOptions {
+  /** Soroban RPC endpoint URL. */
   rpcUrl: string;
+  /**
+   * Stellar network passphrase. When omitted, it is fetched from the RPC
+   * server automatically on the first balance poll and then cached.
+   */
   networkPassphrase?: string;
-  pollInterval?: number; // milliseconds, default 5000
+  /**
+   * How often (in ms) to poll all watched address/token pairs.
+   * @default 5000
+   */
+  pollInterval?: number;
+  /**
+   * Optional callback invoked whenever a polling error occurs for a watched
+   * pair. Replaces the previous silent `console.error` behaviour, giving
+   * callers full control over error handling.
+   *
+   * @param error   The error that was thrown.
+   * @param address The address whose balance could not be fetched.
+   * @param token   The token contract address.
+   */
+  onError?: (error: Error, address: string, token: string) => void;
 }
 
+/** A balance change notification delivered to watch callbacks. */
 export interface BalanceUpdate {
+  /** The Stellar address whose balance changed. */
   address: string;
+  /** The token contract address. */
   token: string;
+  /** The new balance (i128 as bigint). */
   balance: bigint;
+  /** Unix timestamp (ms) when the change was detected. */
   timestamp: number;
 }
 
+/** Called whenever a watched balance changes. */
 export type BalanceCallback = (update: BalanceUpdate) => void;
 
+/** A single address/token pair for bulk fetching. */
+export interface BalancePair {
+  address: string;
+  token: string;
+}
+
+/** Result of a single entry in a bulk `fetchBalances()` call. */
+export interface BalanceFetchResult {
+  address: string;
+  token: string;
+  balance: bigint | null;
+  /** Set when the fetch failed; `balance` will be `null`. */
+  error?: Error;
+}
+
+// ---------------------------------------------------------------------------
+// Internal watcher record
+// ---------------------------------------------------------------------------
+
+interface WatcherRecord {
+  address: string;
+  token: string;
+  lastBalance: bigint | null;
+  callbacks: Set<BalanceCallback>;
+}
+
+// ---------------------------------------------------------------------------
+// BalanceWatcher
+// ---------------------------------------------------------------------------
+
 /**
- * BalanceWatcher monitors token balances for specified addresses
- * and notifies subscribers when balances change.
+ * Monitors token balances for specified addresses and notifies subscribers
+ * when balances change.
+ *
+ * @example
+ * ```ts
+ * const watcher = new BalanceWatcher({
+ *   rpcUrl: 'https://soroban-testnet.stellar.org',
+ *   networkPassphrase: Networks.TESTNET,
+ *   pollInterval: 3000,
+ *   onError: (err, address, token) =>
+ *     console.warn(`Balance fetch failed for ${address}:`, err.message),
+ * });
+ *
+ * // Watch a single address/token pair
+ * const unsub = watcher.watch(senderAddress, tokenContractId, (update) => {
+ *   console.log(`Balance changed to ${update.balance}`);
+ * });
+ *
+ * // Watch all parties involved in a Payment Stream
+ * const unsubStream = watcher.watchStream(stream, tokenContractId, (update) => {
+ *   console.log(`${update.address} balance: ${update.balance}`);
+ * });
+ *
+ * // Later: clean up
+ * unsub();
+ * unsubStream();
+ * watcher.clear();
+ * ```
  */
 export class BalanceWatcher {
-  private rpcServer: SorobanRpc.Server;
+  private readonly rpcServer: SorobanRpc.Server;
   private networkPassphrase: string | undefined;
-  private pollInterval: number;
-  private watchers: Map<string, {
-    address: string;
-    token: string;
-    lastBalance: bigint | null;
-    callbacks: Set<BalanceCallback>;
-  }>;
+  private readonly pollInterval: number;
+  private readonly errorHandler: BalanceWatcherOptions["onError"];
+
+  private watchers: Map<string, WatcherRecord> = new Map();
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private isRunning: boolean = false;
 
@@ -50,23 +140,31 @@ export class BalanceWatcher {
     this.rpcServer = new SorobanRpc.Server(options.rpcUrl);
     this.networkPassphrase = options.networkPassphrase;
     this.pollInterval = options.pollInterval ?? 5000;
+    this.errorHandler = options.onError;
     this.watchers = new Map();
   }
 
+  // ── Single address/token watch ───────────────────────────────────────────
+
   /**
-   * Watch a specific address/token pair for balance changes
-   * @param address The Stellar address to watch
-   * @param token The token contract address
-   * @param callback Function to call when balance changes
-   * @returns Unsubscribe function
+   * Subscribe to balance changes for a specific address/token pair.
+   *
+   * Multiple callbacks can be registered for the same pair; each is called
+   * independently when the balance changes. The pair is polled once
+   * immediately when the first callback is registered.
+   *
+   * @param address  The Stellar address to watch.
+   * @param token    The token contract address.
+   * @param callback Invoked with a {@link BalanceUpdate} whenever the balance changes.
+   * @returns An unsubscribe function. Call it to stop receiving updates.
    */
   public watch(
     address: string,
     token: string,
-    callback: BalanceCallback
+    callback: BalanceCallback,
   ): () => void {
     const key = this.getWatcherKey(address, token);
-    
+
     if (!this.watchers.has(key)) {
       this.watchers.set(key, {
         address,
@@ -76,43 +174,137 @@ export class BalanceWatcher {
       });
     }
 
-    const watcher = this.watchers.get(key)!;
-    watcher.callbacks.add(callback);
+    const record = this.watchers.get(key)!;
+    record.callbacks.add(callback);
 
-    // Start polling if not already running
     if (!this.isRunning) {
       this.start();
     }
 
-    // Return unsubscribe function
-    return () => {
-      watcher.callbacks.delete(callback);
-      if (watcher.callbacks.size === 0) {
-        this.watchers.delete(key);
-        if (this.watchers.size === 0) {
-          this.stop();
-        }
+    return () => this.unwatch(address, token, callback);
+  }
+
+  /**
+   * Remove a single callback from a watched address/token pair.
+   * When no callbacks remain for the pair, the pair is no longer polled.
+   * When no pairs remain, the polling loop is stopped automatically.
+   */
+  public unwatch(
+    address: string,
+    token: string,
+    callback: BalanceCallback,
+  ): void {
+    const key = this.getWatcherKey(address, token);
+    const record = this.watchers.get(key);
+    if (!record) return;
+
+    record.callbacks.delete(callback);
+
+    if (record.callbacks.size === 0) {
+      this.watchers.delete(key);
+      if (this.watchers.size === 0) {
+        this.stop();
       }
+    }
+  }
+
+  // ── Stream-level watch ───────────────────────────────────────────────────
+
+  /**
+   * Convenience method that watches the **sender** and **recipient** of a
+   * Payment Stream simultaneously. A single `callback` receives updates for
+   * both parties, differentiated by `update.address`.
+   *
+   * @param stream   A `Stream` object from the payment-stream contract.
+   * @param token    The token contract address (matches `stream.token`).
+   * @param callback Invoked whenever either party's balance changes.
+   * @returns An unsubscribe function that removes both subscriptions at once.
+   */
+  public watchStream(
+    stream: Pick<Stream, "sender" | "recipient" | "token">,
+    callback: BalanceCallback,
+  ): () => void {
+    const token = stream.token;
+    const unsubSender = this.watch(stream.sender, token, callback);
+    const unsubRecipient = this.watch(stream.recipient, token, callback);
+
+    return () => {
+      unsubSender();
+      unsubRecipient();
     };
   }
 
+  // ── Bulk fetch ───────────────────────────────────────────────────────────
+
   /**
-   * Start the balance polling loop
+   * Fetch the current balance for multiple address/token pairs in parallel.
+   * Failures for individual pairs are captured in the result's `error` field
+   * rather than propagating, so a single failure does not abort the batch.
+   *
+   * @param pairs Array of `{ address, token }` pairs to fetch.
+   * @returns An array of {@link BalanceFetchResult} in the same order as `pairs`.
+   */
+  public async fetchBalances(pairs: BalancePair[]): Promise<BalanceFetchResult[]> {
+    const results = await Promise.allSettled(
+      pairs.map((pair) => this.fetchBalance(pair.address, pair.token)),
+    );
+
+    return results.map((result, i) => {
+      const { address, token } = pairs[i];
+      if (result.status === "fulfilled") {
+        return { address, token, balance: result.value };
+      }
+      return {
+        address,
+        token,
+        balance: null,
+        error: result.reason instanceof Error
+          ? result.reason
+          : new Error(String(result.reason)),
+      };
+    });
+  }
+
+  // ── Cache access ─────────────────────────────────────────────────────────
+
+  /**
+   * Returns the last balance value seen for an address/token pair from the
+   * polling cache, without making any RPC call.
+   *
+   * Returns `null` if:
+   * - The pair has never been polled.
+   * - The pair is not currently being watched.
+   * - The first poll has not yet completed.
+   *
+   * @param address The Stellar address.
+   * @param token   The token contract address.
+   */
+  public getLastKnownBalance(address: string, token: string): bigint | null {
+    const key = this.getWatcherKey(address, token);
+    return this.watchers.get(key)?.lastBalance ?? null;
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────
+
+  /**
+   * Start the polling loop. Called automatically by `watch()`, but can be
+   * called manually if you stopped the loop with `stop()` and want to resume.
    */
   public start(): void {
     if (this.isRunning) return;
-    
+
     this.isRunning = true;
     this.intervalId = setInterval(() => {
-      this.pollBalances();
+      void this.pollBalances();
     }, this.pollInterval);
 
-    // Initial poll
-    this.pollBalances();
+    // Initial poll immediately so callers get a balance update right away
+    void this.pollBalances();
   }
 
   /**
-   * Stop the balance polling loop
+   * Stop the polling loop without removing any watchers.
+   * Call `start()` to resume polling with the existing subscriptions.
    */
   public stop(): void {
     if (this.intervalId) {
@@ -123,65 +315,42 @@ export class BalanceWatcher {
   }
 
   /**
-   * Clear all watchers and stop polling
+   * Remove all watchers and stop the polling loop.
    */
   public clear(): void {
     this.watchers.clear();
     this.stop();
   }
 
+  // ── Introspection ─────────────────────────────────────────────────────────
+
   /**
-   * Poll all watched addresses for balance updates
+   * Returns the number of active address/token pairs currently being watched.
    */
-  private async pollBalances(): Promise<void> {
-    const promises = Array.from(this.watchers.entries()).map(
-      async ([key, watcher]) => {
-        try {
-          const balance = await this.fetchBalance(watcher.address, watcher.token);
-          
-          // Check if balance changed
-          if (watcher.lastBalance === null || balance !== watcher.lastBalance) {
-            watcher.lastBalance = balance;
-            
-            const update: BalanceUpdate = {
-              address: watcher.address,
-              token: watcher.token,
-              balance,
-              timestamp: Date.now(),
-            };
-
-            // Notify all callbacks
-            watcher.callbacks.forEach(callback => {
-              try {
-                callback(update);
-              } catch (error) {
-                console.error("Error in balance callback:", error);
-              }
-            });
-          }
-        } catch (error) {
-          console.error(`Error fetching balance for ${key}:`, error);
-        }
-      }
-    );
-
-    await Promise.allSettled(promises);
+  public getWatcherCount(): number {
+    return this.watchers.size;
   }
 
   /**
-   * Fetch the current balance for an address/token pair by simulating a call
-   * to the token contract's `balance(address)` function via Soroban RPC.
-   *
-   * The simulation is read-only (no transaction is submitted). The result is
-   * parsed from the returned `ScVal` using `scValToNative` and returned as a
-   * `bigint` (token amounts in Soroban are i128).
-   *
-   * @throws {Error} If the RPC simulation fails or returns an unexpected value type.
+   * Returns `true` if the polling loop is running.
    */
-  async fetchBalance(address: string, token: string): Promise<bigint> {
-    const passphrase = await this.resolveNetworkPassphrase();
+  public isActive(): boolean {
+    return this.isRunning;
+  }
 
-    // Build a minimal source account (sequence number doesn't matter for simulation)
+  // ── Core RPC methods ─────────────────────────────────────────────────────
+
+  /**
+   * Fetch the current on-chain balance for a single address/token pair by
+   * simulating a call to the SEP-41 token contract's `balance(address)`
+   * function via Soroban RPC.
+   *
+   * The simulation is read-only — no transaction is ever submitted.
+   *
+   * @throws {Error} If the RPC simulation fails or returns an unexpected type.
+   */
+  public async fetchBalance(address: string, token: string): Promise<bigint> {
+    const passphrase = await this.resolveNetworkPassphrase();
     const sourceAccount = new Account(address, "0");
 
     const tx = new TransactionBuilder(sourceAccount, {
@@ -193,7 +362,7 @@ export class BalanceWatcher {
           contract: token,
           function: "balance",
           args: [new Address(address).toScVal()],
-        })
+        }),
       )
       .setTimeout(0)
       .build();
@@ -204,8 +373,9 @@ export class BalanceWatcher {
       throw new Error(`Balance simulation failed: ${simulation.error}`);
     }
 
-    const retval = (simulation as SorobanRpc.Api.SimulateTransactionSuccessResponse)
-      .result?.retval;
+    const retval = (
+      simulation as SorobanRpc.Api.SimulateTransactionSuccessResponse
+    ).result?.retval;
 
     if (retval === undefined) {
       throw new Error("Balance simulation returned no result");
@@ -215,16 +385,69 @@ export class BalanceWatcher {
 
     if (typeof native !== "bigint") {
       throw new Error(
-        `Unexpected balance type: expected bigint, got ${typeof native} (${native})`
+        `Unexpected balance type: expected bigint, got ${typeof native} (${native})`,
       );
     }
 
     return native;
   }
 
+  // ── Private helpers ───────────────────────────────────────────────────────
+
   /**
-   * Resolves the network passphrase, fetching it from the RPC server if not
-   * provided in the constructor options.
+   * Poll all watched address/token pairs and notify callbacks on changes.
+   */
+  private async pollBalances(): Promise<void> {
+    const promises = Array.from(this.watchers.values()).map(
+      async (record) => {
+        try {
+          const balance = await this.fetchBalance(record.address, record.token);
+
+          if (record.lastBalance === null || balance !== record.lastBalance) {
+            record.lastBalance = balance;
+
+            const update: BalanceUpdate = {
+              address: record.address,
+              token: record.token,
+              balance,
+              timestamp: Date.now(),
+            };
+
+            record.callbacks.forEach((cb) => {
+              try {
+                cb(update);
+              } catch (cbError) {
+                // Callback errors must not stop other callbacks from running
+                console.error("Error in BalanceWatcher callback:", cbError);
+              }
+            });
+          }
+        } catch (error) {
+          const err =
+            error instanceof Error ? error : new Error(String(error));
+
+          if (this.errorHandler) {
+            try {
+              this.errorHandler(err, record.address, record.token);
+            } catch {
+              // Swallow errors thrown by the error handler itself
+            }
+          } else {
+            console.error(
+              `BalanceWatcher: error fetching balance for ${record.address}:${record.token}:`,
+              err,
+            );
+          }
+        }
+      },
+    );
+
+    await Promise.allSettled(promises);
+  }
+
+  /**
+   * Resolves the network passphrase, fetching it from the RPC server if it
+   * was not provided in the constructor options. The result is cached.
    */
   private async resolveNetworkPassphrase(): Promise<string> {
     if (this.networkPassphrase) return this.networkPassphrase;
@@ -233,24 +456,7 @@ export class BalanceWatcher {
     return passphrase;
   }
 
-  /**
-   * Generate a unique key for a watcher
-   */
   private getWatcherKey(address: string, token: string): string {
     return `${address}:${token}`;
-  }
-
-  /**
-   * Get the number of active watchers
-   */
-  public getWatcherCount(): number {
-    return this.watchers.size;
-  }
-
-  /**
-   * Check if the watcher is currently running
-   */
-  public isActive(): boolean {
-    return this.isRunning;
   }
 }


### PR DESCRIPTION
## Summary

Closes #181

Enhances `BalanceWatcher` with the full feature set described in the issue: stream-level subscriptions, bulk balance fetching, a last-known-balance cache, a typed error callback, and an explicit unsubscribe method. The test suite is expanded from 11 to 54 tests covering every new and existing behaviour.

---

## Changes

### `src/utils/BalanceWatcher.ts`

**New methods:**

| Method | Description |
|---|---|
| `watchStream(stream, callback)` | Subscribes to both `sender` and `recipient` of a `Stream` in one call. Returns a single unsub function that tears down both subscriptions atomically. |
| `fetchBalances(pairs)` | Bulk-fetches multiple address/token pairs in parallel. Failures are captured per-pair (`{ balance: null, error }`) so a single RPC error never aborts the batch. |
| `getLastKnownBalance(address, token)` | Returns the cached balance from the last successful poll — no RPC call. Returns `null` before the first poll or when the pair is not watched. |
| `unwatch(address, token, callback)` | Explicit unsubscribe (in addition to the returned closure from `watch()`). |

**New constructor option:**

| Option | Description |
|---|---|
| `onError(error, address, token)` | Typed callback invoked on poll failures instead of silent `console.error`. Gives callers full control over error handling (logging, alerting, retrying). |

**Improvements to existing behaviour:**
- Polling errors for one pair no longer block other pairs from being polled
- `start()` is idempotent — calling it when already running does not create duplicate intervals
- `stop()` is idempotent — calling it when already stopped does not throw
- `void` operator on internal `pollBalances()` call to avoid floating-promise lint warnings

**New exported types:** `BalancePair`, `BalanceFetchResult`

---

### `src/__tests__/BalanceWatcher.test.ts`

Expanded from 11 to **54 tests**:

| Group | Tests |
|---|---|
| `fetchBalance` | Happy path, zero balance, i128 max value, simulation error, no result, non-bigint retval, network rejection, passphrase auto-fetch, passphrase caching |
| `fetchBalances` | All succeed, per-pair error capture without abort, empty input, single pair |
| `getLastKnownBalance` | Before poll, after poll, unwatched pair, after clear, reflects latest poll |
| `watch / unwatch` | Change detection, no-change suppression, change on second poll, multiple callbacks, multi-pair independence, update shape (address/token/balance/timestamp) |
| `unwatch` | Removes specific callback, leaves others intact, removes watcher entry, stops polling when last watcher gone, double-unsub is safe |
| `watchStream` | Registers two watchers, sender callback, recipient callback, unsub removes both, correct token used |
| `onError` | Invoked on failure, correct args, safe if handler throws, per-pair isolation |
| `Lifecycle` | `isActive`, `start`/`stop`/`clear`, idempotency, `getWatcherCount`, interval timing |

---

## Usage example

```ts
const watcher = new BalanceWatcher({
  rpcUrl: 'https://soroban-testnet.stellar.org',
  networkPassphrase: Networks.TESTNET,
  pollInterval: 3000,
  onError: (err, address, token) =>
    console.warn(`Balance fetch failed for ${address}/${token}:`, err.message),
});

// Watch both parties of a stream with one call
const unsub = watcher.watchStream(stream, (update) => {
  console.log(`${update.address}: ${update.balance} (token ${update.token})`);
});

// Bulk fetch without polling
const results = await watcher.fetchBalances([
  { address: sender,    token: tokenContract },
  { address: recipient, token: tokenContract },
]);

// Read cache without RPC
const cached = watcher.getLastKnownBalance(sender, tokenContract);

// Tear down
unsub();
watcher.clear();
```

---

## Testing

```bash
pnpm --filter @fundable/sdk test
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Balance watching now supports tracking multiple address/token pairs at once, cached last-known balances, and watching both sides of a payment stream with one callback.
  * Added a bulk balance lookup that returns results for each pair without failing the whole request.
  * Added configurable error handling for balance polling failures.

* **Bug Fixes**
  * Improved watcher lifecycle behavior, including cleaner unsubscribe handling, better polling start/stop behavior, and more reliable callback notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->