### PR TITLE
feat: web(layout): add font-display swap to next/font configuration

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -12,16 +12,19 @@ import { RootErrorBoundary } from "@/components/ui/root-error-boundary";
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
+  display: "swap",
 });
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+  display: "swap",
 });
 
 const bricolageGrotesque = Bricolage_Grotesque({
   subsets: ["latin"],
   variable: "--font-bricolage-grotesque",
+  display: "swap",
 });
 
 


### PR DESCRIPTION
Closes #462 

### Web font loading causes cumulative layout shift on initial render.

Where
apps/web/src/app/layout.tsx:15-35

Why this is a real bug, not just lint noise
Affects user experience, functionality, or performance in production.
Needs to be addressed to ensure robustness across all supported devices and Stellar network states.
Fix
Configure next/font with display: 'swap'.

Acceptance criteria
 Issue is resolved in apps/web/src/app/layout.tsx:15-35.
 No regression introduced in existing test suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved font loading behavior to display text more quickly while custom fonts load.
  * Reduced the likelihood of invisible text during page startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->