### PR TITLE
fix(web): display offline notification in app shell

### DIFF
--- a/apps/web/src/providers/app-provider.test.tsx
+++ b/apps/web/src/providers/app-provider.test.tsx
@@ -73,6 +73,7 @@ describe("AppProvider offline notification", () => {
   })
 
   it("removes connectivity listeners when unmounted", () => {
+    const addEventListener = vi.spyOn(window, "addEventListener")
     const removeEventListener = vi.spyOn(window, "removeEventListener")
     const { unmount } = render(
       <AppProvider>
@@ -80,9 +81,19 @@ describe("AppProvider offline notification", () => {
       </AppProvider>,
     )
 
+    const onlineListener = addEventListener.mock.calls.find(
+      ([event]) => event === "online",
+    )?.[1]
+    const offlineListener = addEventListener.mock.calls.find(
+      ([event]) => event === "offline",
+    )?.[1]
+
+    expect(onlineListener).toBeDefined()
+    expect(offlineListener).toBeDefined()
+
     unmount()
 
-    expect(removeEventListener).toHaveBeenCalledWith("online", expect.any(Function))
-    expect(removeEventListener).toHaveBeenCalledWith("offline", expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith("online", onlineListener)
+    expect(removeEventListener).toHaveBeenCalledWith("offline", offlineListener)
   })
 })

--- a/apps/web/src/providers/app-provider.test.tsx
+++ b/apps/web/src/providers/app-provider.test.tsx
@@ -1,0 +1,88 @@
+import type { ReactNode } from "react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import AppProvider from "./app-provider"
+
+vi.mock("@/components/ui/sidebar", () => ({
+  SidebarProvider: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@/components/organisms/AdminNavbar", () => ({
+  default: () => <div>Admin navigation</div>,
+}))
+
+vi.mock("@/components/ui/app-sidebar", () => ({
+  AppSidebar: () => <div>App sidebar</div>,
+}))
+
+function setOnlineStatus(isOnline: boolean) {
+  Object.defineProperty(window.navigator, "onLine", {
+    configurable: true,
+    value: isOnline,
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  setOnlineStatus(true)
+})
+
+describe("AppProvider offline notification", () => {
+  it("shows an accessible notification when the app mounts offline", async () => {
+    setOnlineStatus(false)
+
+    render(
+      <AppProvider>
+        <div>Dashboard content</div>
+      </AppProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).not.toBeNull()
+    })
+
+    expect(screen.getByRole("status").getAttribute("aria-live")).toBe("polite")
+    expect(screen.getByRole("status").textContent).toContain("You're offline")
+  })
+
+  it("updates the notification when connectivity changes", async () => {
+    setOnlineStatus(true)
+    render(
+      <AppProvider>
+        <div>Dashboard content</div>
+      </AppProvider>,
+    )
+
+    expect(screen.queryByRole("status")).toBeNull()
+
+    setOnlineStatus(false)
+    fireEvent(window, new Event("offline"))
+
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).not.toBeNull()
+    })
+
+    setOnlineStatus(true)
+    fireEvent(window, new Event("online"))
+
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).toBeNull()
+    })
+  })
+
+  it("removes connectivity listeners when unmounted", () => {
+    const removeEventListener = vi.spyOn(window, "removeEventListener")
+    const { unmount } = render(
+      <AppProvider>
+        <div>Dashboard content</div>
+      </AppProvider>,
+    )
+
+    unmount()
+
+    expect(removeEventListener).toHaveBeenCalledWith("online", expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith("offline", expect.any(Function))
+  })
+})

--- a/apps/web/src/providers/app-provider.tsx
+++ b/apps/web/src/providers/app-provider.tsx
@@ -1,29 +1,46 @@
 "use client";
 
-import React, { type ReactNode } from 'react'
-import { CheckCircle2, XCircle, Loader2, X } from "lucide-react"
+import React, { type ReactNode, useEffect, useState } from 'react'
+import { WifiOff } from "lucide-react"
 import { SidebarProvider } from '@/components/ui/sidebar'
 import AdminNavbar from '@/components/organisms/AdminNavbar'
 import { AppSidebar } from '@/components/ui/app-sidebar'
 
-
-// Set up metadata
-const metadata = {
-  name: 'Fundable',
-  description: "A decentralized funding application.",
-  url: typeof window !== 'undefined' ? window.location.origin : '',
-  icons: ["/favicon_io/favicon.ico"]
-}
-
-
-
 function AppProvider({ children }: { children: ReactNode; }) {
+  const [isOnline, setIsOnline] = useState(true)
+
+  useEffect(() => {
+    const updateOnlineStatus = () => setIsOnline(navigator.onLine)
+
+    updateOnlineStatus()
+    window.addEventListener('online', updateOnlineStatus)
+    window.addEventListener('offline', updateOnlineStatus)
+
+    return () => {
+      window.removeEventListener('online', updateOnlineStatus)
+      window.removeEventListener('offline', updateOnlineStatus)
+    }
+  }, [])
+
   return (
     <div className="pt-20">
       <SidebarProvider className="h-[calc(100dvh-5rem)] min-h-[calc(100dvh-5rem)]">
         <AppSidebar />
         <main className="flex flex-col h-full w-full overflow-hidden">
           <AdminNavbar />
+          {!isOnline && (
+            <div
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              className="sticky top-0 z-50 flex min-h-11 items-center justify-center gap-2 border-b border-amber-700 bg-amber-950 px-4 py-2 text-center text-sm text-amber-100"
+            >
+              <WifiOff className="h-4 w-4 shrink-0" aria-hidden="true" />
+              <span>
+                You&apos;re offline. Network actions are unavailable until your connection is restored.
+              </span>
+            </div>
+          )}
           <div className="flex-1 px-4 py-4 overflow-y-auto pb-16 sm:pb-20 md:pb-4">
             {children}
           </div>


### PR DESCRIPTION
## Summary
- track browser connectivity from the application shell and clean up online/offline listeners on unmount
- show an accessible sticky notification beneath the admin navigation while the browser is offline
- hide the notification immediately when connectivity returns
- cover initial offline state, connectivity transitions, and listener cleanup

## Verification
- `pnpm --filter @fundable/web test -- src/providers/app-provider.test.tsx` (3 passed)
- `pnpm --filter @fundable/web exec eslint src/providers/app-provider.tsx src/providers/app-provider.test.tsx`
- `git diff --check`

## Repository baseline
The full web suite reaches 311 passing tests, then reports pre-existing failures in the Stellar service tests plus a missing `allbridge.service` import. Full TypeScript checking is also blocked by existing syntax errors in unrelated distribution/payment-stream files.

Closes #452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an accessible offline notification that appears when connectivity is lost and disappears when the connection is restored.
  * The notification updates automatically as the browser’s online status changes.

* **Tests**
  * Added coverage for initial offline states, connectivity changes, accessibility attributes, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->