### PR TITLE
fix(error): add collapsible stack panel and copy digest button

### DIFF
--- a/apps/web/src/app/error.test.tsx
+++ b/apps/web/src/app/error.test.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import Error from "./error";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeError(message: string, opts: { stack?: string; digest?: string } = {}): Error & { digest?: string } {
+  const err = new globalThis.Error(message) as Error & { digest?: string };
+  if (opts.stack !== undefined) err.stack = opts.stack;
+  if (opts.digest !== undefined) err.digest = opts.digest;
+  return err;
+}
+
+// ---------------------------------------------------------------------------
+// Generic error (non-env) branch
+// ---------------------------------------------------------------------------
+
+describe("Error boundary – generic error", () => {
+  it("renders the error message", () => {
+    const error = makeError("Something exploded");
+    render(<Error error={error} reset={() => {}} />);
+    expect(screen.getByText("Something exploded")).toBeTruthy();
+  });
+
+  it("renders the 'Something went wrong' heading", () => {
+    const error = makeError("oops");
+    render(<Error error={error} reset={() => {}} />);
+    expect(screen.getByText("Something went wrong")).toBeTruthy();
+  });
+
+  it("renders a 'Try again' button that calls reset", () => {
+    const reset = vi.fn();
+    const error = makeError("oops");
+    render(<Error error={error} reset={reset} />);
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Collapsible stack panel
+  // -------------------------------------------------------------------------
+
+  it("does not render stack toggle when error.stack is absent", () => {
+    const error = makeError("oops");
+    delete error.stack;
+    render(<Error error={error} reset={() => {}} />);
+    expect(screen.queryByRole("button", { name: /show error details/i })).toBeNull();
+  });
+
+  it("renders stack toggle button when error.stack is present", () => {
+    const error = makeError("oops");
+    error.stack = "Error: oops\n    at fn (file.ts:1:1)";
+    render(<Error error={error} reset={() => {}} />);
+    expect(screen.getByRole("button", { name: /show error details/i })).toBeTruthy();
+  });
+
+  it("stack panel is collapsed by default", () => {
+    const stack = "Error: oops\n    at fn (file.ts:1:1)";
+    const error = makeError("oops", { stack });
+    render(<Error error={error} reset={() => {}} />);
+    // The pre element with the stack should not be in the DOM yet
+    expect(screen.queryByText(stack)).toBeNull();
+  });
+
+  it("expands stack panel on first click and collapses on second", () => {
+    const stack = "Error: oops\n    at fn (file.ts:1:1)";
+    const error = makeError("oops", { stack });
+    render(<Error error={error} reset={() => {}} />);
+
+    const toggle = screen.getByRole("button", { name: /show error details/i });
+
+    // Expand
+    fireEvent.click(toggle);
+    // Use a function matcher because the text spans a <pre> with whitespace
+    expect(screen.getByText((_, el) => el?.tagName === "PRE" && el.textContent === stack)).toBeTruthy();
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+
+    // Collapse
+    fireEvent.click(toggle);
+    expect(screen.queryByText((_, el) => el?.tagName === "PRE" && el.textContent === stack)).toBeNull();
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  // -------------------------------------------------------------------------
+  // Copy digest button
+  // -------------------------------------------------------------------------
+
+  it("does not render copy button when digest is absent", () => {
+    const error = makeError("oops");
+    render(<Error error={error} reset={() => {}} />);
+    expect(screen.queryByRole("button", { name: /copy error digest/i })).toBeNull();
+  });
+
+  it("renders digest value and copy button when digest is present", () => {
+    const error = makeError("oops", { digest: "abc-123" });
+    render(<Error error={error} reset={() => {}} />);
+    expect(screen.getByText("abc-123")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /copy error digest/i })).toBeTruthy();
+  });
+
+  it("shows '✓ Copied' feedback after clicking copy and reverts after timeout", async () => {
+    vi.useFakeTimers();
+    // Stub clipboard API
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+
+    const error = makeError("oops", { digest: "abc-123" });
+    render(<Error error={error} reset={() => {}} />);
+
+    const copyBtn = screen.getByRole("button", { name: /copy error digest/i });
+    await act(async () => {
+      fireEvent.click(copyBtn);
+    });
+
+    expect(screen.getByText(/✓ Copied/)).toBeTruthy();
+    expect(writeText).toHaveBeenCalledWith("abc-123");
+
+    // Advance the 2-second timeout
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.queryByText(/✓ Copied/)).toBeNull();
+    expect(screen.getByRole("button", { name: /copy error digest/i })).toBeTruthy();
+
+    vi.useRealTimers();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Environment variable error branch
+// ---------------------------------------------------------------------------
+
+describe("Error boundary – env error", () => {
+  it("renders the configuration error heading", () => {
+    const error = makeError("Environment variable validation failed: NEXT_PUBLIC_RPC_URL");
+    render(<Error error={error} reset={() => {}} />);
+    expect(screen.getByText("⚙️ Configuration Error")).toBeTruthy();
+  });
+
+  it("renders the error message in a pre block", () => {
+    const msg = "Environment variable validation failed: NEXT_PUBLIC_RPC_URL";
+    const error = makeError(msg);
+    render(<Error error={error} reset={() => {}} />);
+    expect(screen.getByText(msg)).toBeTruthy();
+  });
+
+  it("renders the how-to-fix instructions", () => {
+    const error = makeError("Environment variable validation failed");
+    render(<Error error={error} reset={() => {}} />);
+    expect(screen.getByText(/how to fix/i)).toBeTruthy();
+    expect(screen.getByText(/.env.example/i)).toBeTruthy();
+  });
+
+  it("does not render collapsible stack panel for env errors", () => {
+    const error = makeError("Environment variable validation failed");
+    error.stack = "Error: ...\n    at validate (env.ts:1:1)";
+    render(<Error error={error} reset={() => {}} />);
+    // The toggle button should NOT appear in the env-error branch
+    expect(screen.queryByRole("button", { name: /show error details/i })).toBeNull();
+  });
+});

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 export default function Error({
   error,
@@ -9,11 +9,35 @@ export default function Error({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const [stackOpen, setStackOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
   useEffect(() => {
     console.error("Application error:", error);
   }, [error]);
 
   const isEnvError = error.message.includes("Environment variable validation failed");
+
+  async function copyDigest() {
+    if (!error.digest) return;
+    try {
+      await navigator.clipboard.writeText(error.digest);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback for environments where clipboard API is unavailable
+      const textarea = document.createElement("textarea");
+      textarea.value = error.digest;
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
@@ -43,7 +67,53 @@ export default function Error({
               </div>
             </div>
           ) : (
-            <p className="text-gray-700">{error.message}</p>
+            <div>
+              <p className="text-gray-700">{error.message}</p>
+
+              {/* Collapsible stack trace panel */}
+              {error.stack && (
+                <div className="mt-4">
+                  <button
+                    onClick={() => setStackOpen((prev) => !prev)}
+                    aria-expanded={stackOpen}
+                    className="flex items-center gap-1 text-sm font-medium text-gray-500 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
+                  >
+                    <span
+                      aria-hidden="true"
+                      className={`transition-transform duration-200 ${stackOpen ? "rotate-90" : ""}`}
+                    >
+                      ▶
+                    </span>
+                    {stackOpen ? "Hide" : "Show"} error details
+                  </button>
+
+                  {stackOpen && (
+                    <pre className="mt-2 overflow-x-auto rounded bg-gray-100 p-4 text-xs text-gray-700 whitespace-pre-wrap break-words">
+                      {error.stack}
+                    </pre>
+                  )}
+                </div>
+              )}
+
+              {/* Copy digest button */}
+              {error.digest && (
+                <div className="mt-4 flex items-center gap-3">
+                  <span className="text-sm text-gray-500">
+                    Error ID:{" "}
+                    <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-xs text-gray-700">
+                      {error.digest}
+                    </code>
+                  </span>
+                  <button
+                    onClick={copyDigest}
+                    aria-label="Copy error digest to clipboard"
+                    className="rounded border border-gray-300 px-3 py-1 text-xs text-gray-600 transition-colors hover:border-gray-400 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  >
+                    {copied ? "✓ Copied" : "Copy"}
+                  </button>
+                </div>
+              )}
+            </div>
           )}
         </div>
 


### PR DESCRIPTION
- Show error.stack in a collapsible <pre> panel with aria-expanded toggle
- Display error.digest with a copy-to-clipboard button and '✓ Copied' feedback
- Both features are conditionally rendered; env-error branch unchanged
- Add error.test.tsx with 14 tests covering all new behaviour
- closes #450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expandable error details for viewing stack traces.
  * Added error digest display with one-click copying and confirmation feedback.
  * Added a retry action for recoverable errors.
  * Preserved dedicated configuration-error guidance, including `.env.example` instructions.

* **Tests**
  * Added comprehensive coverage for error messages, retry behavior, stack details, digest copying, copy feedback, and configuration-error rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->