### PR TITLE
fix(web): handle 429 responses in offramp quotes

### DIFF
--- a/apps/web/src/hooks/useOfframpBridge.rate-limit.test.ts
+++ b/apps/web/src/hooks/useOfframpBridge.rate-limit.test.ts
@@ -1,0 +1,100 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import toast from "react-hot-toast";
+
+import { useWallet } from "@/providers/StellarWalletProvider";
+import { offrampService } from "@/services/offramp.service";
+
+import { useOfframpBridge } from "./useOfframpBridge";
+
+vi.mock("react-hot-toast", () => ({
+    default: {
+        error: vi.fn(),
+    },
+}));
+
+vi.mock("@/providers/StellarWalletProvider", () => ({
+    useWallet: vi.fn(),
+}));
+
+vi.mock("@/services/offramp.service", () => ({
+    offrampService: {
+        getBankList: vi.fn(),
+        verifyBankAccount: vi.fn(),
+        getAggregatedRates: vi.fn(),
+        createOfframp: vi.fn(),
+        getQuoteStatus: vi.fn(),
+    },
+}));
+
+const mockWallet = {
+    address: "GABC123",
+    isConnected: true,
+};
+
+async function requestQuote() {
+    const hook = renderHook(() => useOfframpBridge());
+
+    act(() => {
+        hook.result.current.handleFormChange("amount", "10");
+    });
+
+    await act(async () => {
+        await vi.runAllTimersAsync();
+    });
+
+    return hook;
+}
+
+describe("useOfframpBridge rate limit handling", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+        vi.mocked(useWallet).mockReturnValue(mockWallet as ReturnType<typeof useWallet>);
+        vi.mocked(offrampService.getBankList).mockResolvedValue({
+            success: true,
+            data: [],
+        });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("shows the rate limit toast when the rates API returns 429", async () => {
+        vi.mocked(offrampService.getAggregatedRates).mockResolvedValue({
+            success: false,
+            status: 429,
+            error: "Too many requests",
+        });
+
+        const { result } = await requestQuote();
+
+        expect(result.current.quote).toBeNull();
+        expect(result.current.quoteError).toBe("Rate limit exceeded. Please wait");
+        expect(toast.error).toHaveBeenCalledOnce();
+        expect(toast.error).toHaveBeenCalledWith("Rate limit exceeded. Please wait");
+    });
+
+    it("handles a thrown 429 error without leaking a runtime exception", async () => {
+        vi.mocked(offrampService.getAggregatedRates).mockRejectedValue({
+            response: { status: 429 },
+        });
+
+        const { result } = await requestQuote();
+
+        expect(result.current.quoteError).toBe("Rate limit exceeded. Please wait");
+        expect(toast.error).toHaveBeenCalledWith("Rate limit exceeded. Please wait");
+    });
+
+    it("preserves the generic message for other network errors", async () => {
+        vi.mocked(offrampService.getAggregatedRates).mockRejectedValue(
+            new Error("Network error"),
+        );
+
+        const { result } = await requestQuote();
+
+        expect(result.current.quoteError).toBe("Failed to fetch rates");
+        expect(toast.error).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/hooks/useOfframpBridge.ts
+++ b/apps/web/src/hooks/useOfframpBridge.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState, useRef, useEffect } from "react";
+import toast from "react-hot-toast";
 import { useWallet } from "@/providers/StellarWalletProvider";
 import { offrampService } from "@/services/offramp.service";
 import type {
@@ -13,6 +14,33 @@ import type {
     ProviderRate,
 } from "@/types/offramp";
 import { SUPPORTED_OFFRAMP_TOKENS, getAccountNumberRules } from "@/types/offramp";
+
+const RATE_LIMIT_MESSAGE = "Rate limit exceeded. Please wait";
+
+function isRateLimitError(error: unknown): boolean {
+    if (typeof error === "object" && error !== null) {
+        if ("status" in error && error.status === 429) return true;
+
+        if (
+            "response" in error &&
+            typeof error.response === "object" &&
+            error.response !== null &&
+            "status" in error.response &&
+            error.response.status === 429
+        ) {
+            return true;
+        }
+    }
+
+    const message =
+        error instanceof Error
+            ? error.message
+            : typeof error === "string"
+                ? error
+                : "";
+
+    return /\b429\b|rate limit|too many requests/i.test(message);
+}
 
 interface UseOfframpBridgeReturn {
     // State
@@ -217,13 +245,26 @@ export function useOfframpBridge(): UseOfframpBridgeReturn {
                     setQuote(result.data.best);
                     setQuoteError(null);
                 } else {
+                    const rateLimited =
+                        result.status === 429 || isRateLimitError(result.error);
+                    const message = rateLimited
+                        ? RATE_LIMIT_MESSAGE
+                        : result.error || "No rates available";
+
                     setQuote(null);
-                    setQuoteError(result.error || "No rates available");
+                    setQuoteError(message);
+                    if (rateLimited) toast.error(message);
                 }
-            } catch {
+            } catch (error) {
                 if (!controller.signal.aborted) {
+                    const rateLimited = isRateLimitError(error);
+                    const message = rateLimited
+                        ? RATE_LIMIT_MESSAGE
+                        : "Failed to fetch rates";
+
                     setQuote(null);
-                    setQuoteError("Failed to fetch rates");
+                    setQuoteError(message);
+                    if (rateLimited) toast.error(message);
                 }
             } finally {
                 if (!controller.signal.aborted) setIsLoadingQuote(false);

--- a/apps/web/src/services/offramp.service.ts
+++ b/apps/web/src/services/offramp.service.ts
@@ -94,6 +94,7 @@ const realOfframpService = {
             if (!res.ok) {
                 return {
                     success: false,
+                    status: res.status,
                     error: data.message || data.error || "Failed to get rates",
                 };
             }

--- a/apps/web/src/types/offramp.ts
+++ b/apps/web/src/types/offramp.ts
@@ -113,6 +113,7 @@ export interface ProviderRate {
 
 export interface AggregatedRatesResponse {
     success: boolean;
+    status?: number;
     data?: {
         best: ProviderRate | null;
         all: ProviderRate[];


### PR DESCRIPTION
## Summary
- preserve the HTTP status returned by the aggregated rates endpoint
- show "Rate limit exceeded. Please wait" when a 429 response is returned or thrown
- keep the existing generic message for non-rate-limit failures
- add focused hook coverage for response, thrown-error, and generic-error paths

## Validation
- targeted rate-limit tests: 3/3 passed
- ESLint on all changed files: no errors; one pre-existing exhaustive-deps warning remains
- git diff --check passed
- full web suite: 311 passed; two pre-existing StellarService failures and the pre-existing unresolved allbridge service suite remain
- full TypeScript check remains blocked by pre-existing syntax errors in unrelated files

Closes #445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rate-limit errors when fetching off-ramp quotes.
  * Displays a clear rate-limit message and notification when requests are throttled.
  * Preserves generic error messaging for other network failures.
  * Prevents rate-limit failures from causing runtime exceptions.

* **Tests**
  * Added coverage for rate-limit responses, rejected requests, and general network errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->