### PR TITLE
feat(constants): add STELLAR_NETWORK constant for dynamic network con…

### DIFF
--- a/apps/web/src/components/offramp/OfframpSuccessModal.tsx
+++ b/apps/web/src/components/offramp/OfframpSuccessModal.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import toast from "react-hot-toast";
 import type { QuoteStatusData } from "@/types/offramp";
-import { STELLAR_EXPERT_URL } from "@/lib/constants";
+import { STELLAR_EXPERT_URL, STELLAR_NETWORK } from "@/lib/constants";
  
 interface OfframpSuccessModalProps {
     isOpen: boolean;
@@ -100,7 +100,7 @@ export default function OfframpSuccessModal({
  
                     {bridgeTxHash && (
                         <a
-                            href={`${STELLAR_EXPERT_URL}/tx/${bridgeTxHash}`}
+                            href={`${STELLAR_EXPERT_URL}/tx/${bridgeTxHash}?network=${STELLAR_NETWORK}`}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="flex items-center justify-center gap-2 w-full py-3 text-xs text-fundable-purple hover:text-fundable-violet transition-colors font-medium"

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -4,6 +4,7 @@ export const PAYMENT_STREAM_CONTRACT_ID = env.NEXT_PUBLIC_PAYMENT_STREAM_CONTRAC
 export const DISTRIBUTOR_CONTRACT_ID = env.NEXT_PUBLIC_DISTRIBUTOR_CONTRACT_ID;
 export const SOROBAN_RPC_URL = env.NEXT_PUBLIC_SOROBAN_RPC_URL;
 export const NETWORK_PASSPHRASE = env.NEXT_PUBLIC_NETWORK_PASSPHRASE;
+export const STELLAR_NETWORK = env.NEXT_PUBLIC_STELLAR_NETWORK;
 
 // Distribution
 export const distributionType = ["equal", "weighted"] as const;


### PR DESCRIPTION
Closes #446 

# PR: fix(web): construct Stellar Expert explorer link dynamically from env config

## Description

The Stellar Expert explorer link in the offramp success modal was missing a `?network=` query parameter, causing Stellar Expert to default to mainnet even when the app runs on Testnet. This fix appends the network identifier dynamically using the validated `NEXT_PUBLIC_STELLAR_NETWORK` environment variable.

## Related Issue

Closes #446

## Changes

| File | Change |
|------|--------|
| `apps/web/src/lib/constants.ts` | Added `STELLAR_NETWORK` export sourced from `env.NEXT_PUBLIC_STELLAR_NETWORK` |
| `apps/web/src/components/offramp/OfframpSuccessModal.tsx` | Imported `STELLAR_NETWORK` and appended `?network=${STELLAR_NETWORK}` to the explorer link |

## Diff

```diff
diff --git a/apps/web/src/lib/constants.ts b/apps/web/src/lib/constants.ts
--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -4,6 +4,7 @@ export const PAYMENT_STREAM_CONTRACT_ID = env.NEXT_PUBLIC_PAYMENT_STREAM_CONTRAC
 export const DISTRIBUTOR_CONTRACT_ID = env.NEXT_PUBLIC_DISTRIBUTOR_CONTRACT_ID;
 export const SOROBAN_RPC_URL = env.NEXT_PUBLIC_SOROBAN_RPC_URL;
 export const NETWORK_PASSPHRASE = env.NEXT_PUBLIC_NETWORK_PASSPHRASE;
+export const STELLAR_NETWORK = env.NEXT_PUBLIC_STELLAR_NETWORK;
 
 // Distribution
 export const distributionType = ["equal", "weighted"] as const;
diff --git a/apps/web/src/components/offramp/OfframpSuccessModal.tsx b/apps/web/src/components/offramp/OfframpSuccessModal.tsx
--- a/apps/web/src/components/offramp/OfframpSuccessModal.tsx
+++ b/apps/web/src/components/offramp/OfframpSuccessModal.tsx
@@ -12,7 +12,7 @@
 } from "@/components/ui/dialog";
 import toast from "react-hot-toast";
 import type { QuoteStatusData } from "@/types/offramp";
-import { STELLAR_EXPERT_URL } from "@/lib/constants";
+import { STELLAR_EXPERT_URL, STELLAR_NETWORK } from "@/lib/constants";
 
 interface OfframpSuccessModalProps {
     isOpen: boolean;
@@ -100,7 +100,7 @@

                     {bridgeTxHash && (
                         <a
-                            href={`${STELLAR_EXPERT_URL}/tx/${bridgeTxHash}`}
+                            href={`${STELLAR_EXPERT_URL}/tx/${bridgeTxHash}?network=${STELLAR_NETWORK}`}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="flex items-center justify-center gap-2 w-full py-3 text-xs text-fundable-purple hover:text-fundable-violet transition-colors font-medium"
```

## Result

| Environment | Before | After |
|-------------|--------|-------|
| Testnet | `stellar.expert/explorer/testnet/tx/{hash}` | `stellar.expert/explorer/testnet/tx/{hash}?network=testnet` |
| Mainnet | `stellar.expert/explorer/public/tx/{hash}` | `stellar.expert/explorer/public/tx/{hash}?network=mainnet` |

## Acceptance Criteria

- [x] Explorer link in `OfframpSuccessModal.tsx:40-60` resolves dynamically based on `NEXT_PUBLIC_STELLAR_NETWORK`
- [x] No existing exports or imports broken in `constants.ts`
- [ ] `npm test` passes (run locally - `node_modules` not installed in CI env)
- [ ] `npm run lint` passes (run locally)

## Testing

No existing unit tests cover `OfframpSuccessModal`. Manual verification:

1. Set `NEXT_PUBLIC_STELLAR_NETWORK=testnet` in `.env.local` -> link should include `?network=testnet`
2. Set `NEXT_PUBLIC_STELLAR_NETWORK=mainnet` in `.env.local` -> link should include `?network=mainnet`
3. Open the offramp modal with a valid `bridgeTxHash` and confirm the link opens the correct network on Stellar Expert


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “View Stellar Explorer” link to include the configured network, ensuring transactions open in the correct network context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->