### PR TITLE
fix(ToastProvider): limit max concurrent visible toasts and set gutte…

### DIFF
--- a/apps/web/src/providers/ToastProvider.tsx
+++ b/apps/web/src/providers/ToastProvider.tsx
@@ -1,10 +1,23 @@
 "use client";
-import { Toaster } from "react-hot-toast";
+import { useEffect } from "react";
+import { Toaster, useToasterStore, toast } from "react-hot-toast";
+
+const TOAST_LIMIT = 3;
 
 export const ToastProvider = () => {
+  const { toasts } = useToasterStore();
+
+  useEffect(() => {
+    toasts
+      .filter((t) => t.visible)
+      .filter((_, i) => i >= TOAST_LIMIT)
+      .forEach((t) => toast.dismiss(t.id));
+  }, [toasts]);
+
   return (
     <Toaster
       position="top-right"
+      gutter={12}
       toastOptions={{
         className: "",
         style: {


### PR DESCRIPTION
# Title: fix(ToastProvider): limit max concurrent visible toasts and set gutter spacing

## Description
451 web(ToastProvider): limit max concurrent visible toasts and set gutter spacing
Close #451
This PR resolves the issue where rapid toast triggers stack visually on top of each other, creating a poor user experience.

### Changes Made:
- Configured the toast provider with a maximum visible limit of `3` concurrent toasts by implementing the `useToasterStore` hook from `react-hot-toast` inside the `ToastProvider`.
- Added a `gutter` spacing of `12px` to the `<Toaster />` component to ensure distinct visual separation between active toasts.
- Programmatically dismisses the oldest toasts when the limit is exceeded.

## Related Issues
- Resolves #451: web(ToastProvider): limit max concurrent visible toasts and set gutter spacing

## Acceptance Criteria Met
- [x] Issue is resolved in `apps/web/src/providers/ToastProvider.tsx:10-25`.
- [x] No regression introduced in existing test suites.

## Testing Instructions
1. Trigger multiple toast notifications rapidly in the UI.
2. Observe that only up to 3 toasts are visible on the screen simultaneously.
3. Observe that there is adequate space (gutter) between multiple visible toasts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited the number of simultaneously visible toast notifications.
  * Improved spacing between toast notifications for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->