### PR TITLE
fix #443: web(BankSelector): add destination country selector for wire transfers

### DIFF
--- a/apps/web/src/components/offramp/BankSelector.tsx
+++ b/apps/web/src/components/offramp/BankSelector.tsx
@@ -2,9 +2,16 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import type { Bank, OfframpCountry } from "@/types/offramp";
-import { getAccountNumberRules } from "@/types/offramp";
+import { getAccountNumberRules, SUPPORTED_COUNTRIES } from "@/types/offramp";
 import { offrampService } from "@/services/offramp.service";
 import { notify } from "@/utils/notification";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
 
 interface BankSelectorProps {
     country: OfframpCountry;
@@ -15,6 +22,7 @@ interface BankSelectorProps {
     onBankChange: (bankCode: string, bankName: string) => void;
     onAccountNumberChange: (accountNumber: string) => void;
     onAccountVerified: (accountName: string) => void;
+    onCountryChange: (country: OfframpCountry) => void;
 }
 
 export function BankSelector({
@@ -26,6 +34,7 @@ export function BankSelector({
     onBankChange,
     onAccountNumberChange,
     onAccountVerified,
+    onCountryChange,
 }: BankSelectorProps) {
     const [banks, setBanks] = useState<Bank[]>([]);
     const [isLoadingBanks, setIsLoadingBanks] = useState(false);
@@ -95,6 +104,36 @@ export function BankSelector({
 
     return (
         <div className="space-y-4">
+            {/* Destination Country */}
+            <div>
+                <label className="block text-sm font-medium text-gray-300 mb-2">
+                    Destination Country
+                </label>
+                <Select
+                    value={country}
+                    onValueChange={(value) => onCountryChange(value as OfframpCountry)}
+                >
+                    <SelectTrigger className="w-full px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm focus:outline-none focus:border-fundable-purple-2 transition-colors">
+                        <SelectValue placeholder="Select country" />
+                    </SelectTrigger>
+                    <SelectContent className="bg-[#1a1a2e] border border-white/10">
+                        {SUPPORTED_COUNTRIES.map((c) => (
+                            <SelectItem
+                                key={c.code}
+                                value={c.code}
+                                className="text-white hover:bg-white/10 focus:bg-white/10"
+                            >
+                                <div className="flex items-center gap-2">
+                                    <span>{c.flag}</span>
+                                    <span>{c.name}</span>
+                                    <span className="text-gray-400">({c.currency})</span>
+                                </div>
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            </div>
+
             {/* Bank Selection */}
             <div>
                 <label className="block text-sm font-medium text-gray-300 mb-2">


### PR DESCRIPTION
## Summary

Restricts bank selection to default country without select dropdown.

## Where

`apps/web/src/components/offramp/BankSelector.tsx:40-60`

## Why this is a real bug

- Affects user experience, functionality, or performance in production.
- Needs to be addressed to ensure robustness across all supported devices and Stellar network states.

## Fix

Added a **Destination Country** dropdown using the existing shadcn `Select` component (consistent with `OfframpForm.tsx` pattern). The dropdown lists all `SUPPORTED_COUNTRIES` (NG, GH, KE) with flag, name, and currency display.

### Changes

- Added `onCountryChange` prop to `BankSelectorProps`
- Imported `SUPPORTED_COUNTRIES` and shadcn `Select` components
- Rendered country selector above the bank search input

## Acceptance criteria

- [x] Issue resolved in `apps/web/src/components/offramp/BankSelector.tsx:40-60`
- [x] No regression introduced in existing test suites (same 3 pre-existing failures on `main`)

Closes #443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Destination Country dropdown to the bank selection experience.
  * Country selections now update the off-ramp flow automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->