### PR TITLE
fix: wrap signTransaction in 60-second timeout to prevent hang on loc…

### DIFF
--- a/apps/web/src/providers/StellarWalletProvider.tsx
+++ b/apps/web/src/providers/StellarWalletProvider.tsx
@@ -287,11 +287,22 @@ export const StellarWalletProvider = ({
   const signTransaction = useCallback(
     async (xdr: string) => {
       if (!kit || !address) throw new Error("Wallet not connected");
+
+      let timeoutId: ReturnType<typeof setTimeout>;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error("Sign transaction timed out after 60 seconds. Please unlock your wallet and try again."));
+        }, 60000);
+      });
+
       try {
-        const { signedTxXdr } = await kit.signTransaction(xdr);
+        const { signedTxXdr } = await Promise.race([
+          kit.signTransaction(xdr),
+          timeoutPromise,
+        ]);
         return signedTxXdr;
-      } catch (error) {
-        throw error;
+      } finally {
+        clearTimeout(timeoutId!);
       }
     },
     [kit, address],


### PR DESCRIPTION
…ked Ledger

Ledger signature requests hang indefinitely when the device is locked, freezing the UI with no feedback. This wraps kit.signTransaction in a Promise.race against a 60-second timeout, so the caller gets a clear error message instead of hanging forever.

Closes #388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 60-second timeout when signing transactions.
  * Improved handling of signing completion and timeouts to prevent transactions from waiting indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->