### PR TITLE
fix(web): announce stream validation errors

### DIFF
--- a/apps/web/src/components/modules/payment-stream/PaymentStreamForm.test.tsx
+++ b/apps/web/src/components/modules/payment-stream/PaymentStreamForm.test.tsx
@@ -1,0 +1,48 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { PaymentStreamForm } from "./PaymentStreamForm"
+
+const baseStreamData = {
+  name: "Test stream",
+  recipient: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  token: "XLM",
+  amount: "10",
+  duration: "day",
+  durationValue: "1",
+  cancellability: false,
+  transferability: false,
+}
+
+const baseProps = {
+  tokenOptions: [{ label: "XLM", value: "XLM" }],
+  setStreamData: vi.fn(),
+  durationOptions: [{ label: "Day", value: "day" }],
+  onSubmit: vi.fn(),
+  isSubmitting: false,
+}
+
+describe("PaymentStreamForm", () => {
+  it("announces dynamic end-time validation errors politely", () => {
+    const { container, rerender } = render(
+      <PaymentStreamForm streamData={baseStreamData} {...baseProps} />
+    )
+    const liveRegion = container.querySelector(
+      '[aria-live="polite"][aria-atomic="true"]'
+    )
+
+    expect(liveRegion).not.toBeNull()
+    expect(liveRegion?.textContent).toBe("")
+
+    rerender(
+      <PaymentStreamForm
+        streamData={{ ...baseStreamData, durationValue: "0" }}
+        {...baseProps}
+      />
+    )
+
+    expect(liveRegion?.textContent).toContain(
+      "Duration must be greater than zero"
+    )
+  })
+})

--- a/apps/web/src/components/modules/payment-stream/PaymentStreamForm.tsx
+++ b/apps/web/src/components/modules/payment-stream/PaymentStreamForm.tsx
@@ -177,13 +177,15 @@ export function PaymentStreamForm({
               />
             </div>
 
-            {/* End Time Validation Error */}
-            {endTimeValidation.error && (
-              <div className="mt-2 flex items-start gap-2 text-red-400 text-sm">
-                <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
-                <span>{endTimeValidation.error}</span>
-              </div>
-            )}
+            <div aria-live="polite" aria-atomic="true">
+              {/* End Time Validation Error */}
+              {endTimeValidation.error && (
+                <div className="mt-2 flex items-start gap-2 text-red-400 text-sm">
+                  <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+                  <span>{endTimeValidation.error}</span>
+                </div>
+              )}
+            </div>
 
             {/* End Time Preview */}
             {endTimeValidation.isValid && endTimeValidation.endTime && (


### PR DESCRIPTION
## Summary
- keep a persistent polite live region around payment stream end-time validation
- mark updates atomic so assistive technology announces the complete message
- add a focused rerender test for dynamically appearing validation feedback

## Testing
- `pnpm --filter @fundable/web test -- src/components/modules/payment-stream/PaymentStreamForm.test.tsx` (1 passed)
- `pnpm --filter @fundable/web exec eslint src/components/modules/payment-stream/PaymentStreamForm.tsx src/components/modules/payment-stream/PaymentStreamForm.test.tsx`
- `git diff --check`

## Existing CI baseline
- Frontend CI reaches this change but fails on 43 unrelated repository-wide lint errors; the changed files pass ESLint.
- Contracts CI fails while compiling `soroban-env-host` because of the existing `ed25519-dalek`/`rand_core` dependency mismatch.
- The current `main` branch is failing the same Frontend and Contracts workflows.

Closes #410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen-reader announcements for payment stream duration validation errors.

* **Tests**
  * Added coverage to verify that invalid duration messages are announced correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->