### PR TITLE
fix(web): enforce min start time of now + 60s in stream validation schema

### DIFF
--- a/apps/web/src/components/modules/payment-stream/CreatePaymentStream.tsx
+++ b/apps/web/src/components/modules/payment-stream/CreatePaymentStream.tsx
@@ -101,7 +101,7 @@ const CreatePaymentStream = () => {
           data.duration === 'week' ? 604800 :
             data.duration === 'month' ? 2592000 : 31536000;
       const durationInSeconds = Math.floor(parseFloat(data.durationValue) * durationMultiplier);
-      const startTime = BigInt(Math.floor(Date.now() / 1000));
+      const startTime = BigInt(Math.floor(Date.now() / 1000) + 60); // 60s buffer for on-chain latency
 
       const fee = await realStellarService.getStreamCreationFeeEstimate({
         recipient: data.recipient,

--- a/apps/web/src/lib/__tests__/stream-validation.test.ts
+++ b/apps/web/src/lib/__tests__/stream-validation.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Tests for stream validation utilities
+ * **Issue #398: Prevent selecting past start times in date picker**
+ * **Enforces: min start time of now + 60s**
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  validateStartTime,
+  validateEndTime,
+  calculateEndTime,
+  getMinStartTime,
+  MIN_START_TIME_OFFSET_SECONDS,
+  formatEndTime,
+  getRelativeTime,
+  durationToSeconds,
+  type DurationUnit,
+} from '../stream-validation';
+
+// Helper to freeze time at a known Unix timestamp
+const NOW = 1_000_000_000; // Arbitrary fixed timestamp
+
+/** How close two numbers must be after a time-sensitive call (allow 1s variance) */
+function expectCloseTo(actual: number, expected: number, tolerance = 1) {
+  expect(Math.abs(actual - expected)).toBeLessThanOrEqual(tolerance);
+}
+
+describe('MIN_START_TIME_OFFSET_SECONDS', () => {
+  it('should be exactly 60 seconds', () => {
+    expect(MIN_START_TIME_OFFSET_SECONDS).toBe(60);
+  });
+});
+
+describe('getMinStartTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW * 1000));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should return now + 60 seconds', () => {
+    expect(getMinStartTime()).toBe(NOW + 60);
+  });
+});
+
+describe('validateStartTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW * 1000));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // --- null (no explicit start time) is valid ---
+
+  it('should accept null (no explicit start time selected)', () => {
+    expect(validateStartTime(null)).toBeNull();
+  });
+
+  // --- Rejection cases ---
+
+  it('should reject startTime exactly at now (too early)', () => {
+    expect(validateStartTime(NOW)).toBe(
+      'Start time must be at least 60 seconds from now',
+    );
+  });
+
+  it('should reject startTime in the past', () => {
+    expect(validateStartTime(NOW - 3600)).toBe(
+      'Start time must be at least 60 seconds from now',
+    );
+  });
+
+  it('should reject startTime slightly before the minimum offset (now+59)', () => {
+    expect(validateStartTime(NOW + 59)).toBe(
+      'Start time must be at least 60 seconds from now',
+    );
+  });
+
+  // --- Acceptance cases ---
+
+  it('should accept startTime exactly at the minimum offset (now+60)', () => {
+    expect(validateStartTime(NOW + 60)).toBeNull();
+  });
+
+  it('should accept startTime well in the future', () => {
+    expect(validateStartTime(NOW + 86400)).toBeNull();
+  });
+
+  it('should accept startTime far in the future', () => {
+    expect(validateStartTime(NOW + 31536000)).toBeNull();
+  });
+});
+
+describe('calculateEndTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW * 1000));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should use getMinStartTime() when startTime is null', () => {
+    const endTime = calculateEndTime(null, 1, 'hour');
+    // effective start = getMinStartTime() = NOW + 60, plus 3600s = NOW + 3660
+    expect(endTime).toBe(NOW + 60 + 3600);
+  });
+
+  it('should use explicit startTime when provided', () => {
+    const endTime = calculateEndTime(NOW + 60, 2, 'hour');
+    expect(endTime).toBe(NOW + 60 + 7200);
+  });
+
+  it('should handle week duration unit', () => {
+    const endTime = calculateEndTime(NOW + 60, 1, 'week');
+    expect(endTime).toBe(NOW + 60 + 604800);
+  });
+
+  it('should handle month duration unit', () => {
+    const endTime = calculateEndTime(NOW + 60, 1, 'month');
+    expect(endTime).toBe(NOW + 60 + 2592000);
+  });
+
+  it('should handle year duration unit', () => {
+    const endTime = calculateEndTime(NOW + 60, 1, 'year');
+    expect(endTime).toBe(NOW + 60 + 31536000);
+  });
+});
+
+describe('validateEndTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW * 1000));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // --- Success paths ---
+
+  it('should accept null startTime with a long-enough duration (1 hour)', () => {
+    // effective start = NOW + 60, endTime = NOW + 60 + 3600 = NOW + 3660 >= NOW + 60 ✓
+    expect(validateEndTime(null, '1', 'hour')).toBeNull();
+  });
+
+  it('should accept null startTime with a short valid duration (1 minute)', () => {
+    // effective start = NOW + 60, endTime = NOW + 60 + 60 = NOW + 120 >= NOW + 60 ✓
+    // The "hour" unit makes 1 hour = 3600s, so this is fine
+    expect(validateEndTime(null, '1', 'hour')).toBeNull();
+  });
+
+  it('should accept an explicit valid startTime (now+60) with a regular duration', () => {
+    expect(validateEndTime(NOW + 60, '1', 'hour')).toBeNull();
+  });
+
+  it('should accept an explicit future startTime (now+86400) with any duration', () => {
+    expect(validateEndTime(NOW + 86400, '1', 'hour')).toBeNull();
+  });
+
+  // --- Failure paths: duration parsing ---
+
+  it('should reject an empty duration string', () => {
+    expect(validateEndTime(null, '', 'hour')).toBe(
+      'Duration must be a valid number',
+    );
+  });
+
+  it('should reject a non-numeric duration', () => {
+    expect(validateEndTime(null, 'abc', 'hour')).toBe(
+      'Duration must be a valid number',
+    );
+  });
+
+  it('should reject duration of zero', () => {
+    expect(validateEndTime(null, '0', 'hour')).toBe(
+      'Duration must be greater than zero',
+    );
+  });
+
+  it('should reject a negative duration', () => {
+    expect(validateEndTime(null, '-5', 'hour')).toBe(
+      'Duration must be greater than zero',
+    );
+  });
+
+  it('should reject an invalid duration unit', () => {
+    expect(validateEndTime(null, '1', 'lightyear')).toBe(
+      'Invalid duration unit',
+    );
+  });
+
+  // --- Failure paths: start time validation ---
+
+  it('should reject an explicit past startTime (now-3600) even with a long duration', () => {
+    expect(validateEndTime(NOW - 3600, '24', 'hour')).toBe(
+      'Start time must be at least 60 seconds from now',
+    );
+  });
+
+  it('should reject an explicit startTime exactly at now', () => {
+    expect(validateEndTime(NOW, '1', 'hour')).toBe(
+      'Start time must be at least 60 seconds from now',
+    );
+  });
+
+  it('should reject an explicit startTime just under the minimum (now+59)', () => {
+    expect(validateEndTime(NOW + 59, '1', 'hour')).toBe(
+      'Start time must be at least 60 seconds from now',
+    );
+  });
+
+  // --- Failure paths: end time too close ---
+
+  it('should enforce the minimum end-time offset for all valid duration inputs', () => {
+    // For any valid input (duration > 0, valid unit), endTime should always
+    // exceed minEndTime because calculateEndTime's effective start is now+60
+    // and the minimum positive duration (1 hour = 3600s) pushes endTime well past it.
+    // This invariant is tested across multiple duration/unit combinations.
+    const minValidCases = [
+      { startTime: null, durationValue: '1', durationUnit: 'hour' },
+      { startTime: NOW + 60, durationValue: '1', durationUnit: 'hour' },
+      { startTime: null, durationValue: '1', durationUnit: 'day' },
+      { startTime: null, durationValue: '1', durationUnit: 'week' },
+      { startTime: null, durationValue: '1', durationUnit: 'month' },
+      { startTime: null, durationValue: '1', durationUnit: 'year' },
+    ];
+
+    for (const { startTime, durationValue, durationUnit } of minValidCases) {
+      expect(validateEndTime(startTime, durationValue, durationUnit)).toBeNull();
+    }
+  });
+
+  // --- Edge cases ---
+
+  it('should handle very large duration values', () => {
+    expect(validateEndTime(null, '999999', 'year')).toBeNull();
+  });
+
+  it('should handle decimal duration values (parseInt floors to integer)', () => {
+    // parseInt('1.5') = 1, so it's valid
+    expect(validateEndTime(null, '1.5', 'hour')).toBeNull();
+  });
+
+  it('should handle duration with leading/trailing whitespace', () => {
+    // parseInt handles whitespace
+    expect(validateEndTime(null, '  1  ', 'hour')).toBeNull();
+  });
+
+  it('should be consistent across repeated calls with various inputs', () => {
+    const testCases: Array<{
+      startTime: number | null;
+      durationValue: string;
+      durationUnit: string;
+      expected: string | null;
+    }> = [
+      // Valid cases
+      { startTime: null, durationValue: '1', durationUnit: 'hour', expected: null },
+      { startTime: NOW + 60, durationValue: '1', durationUnit: 'hour', expected: null },
+      { startTime: NOW + 86400, durationValue: '7', durationUnit: 'day', expected: null },
+      // Invalid duration
+      { startTime: null, durationValue: '', durationUnit: 'hour', expected: 'Duration must be a valid number' },
+      { startTime: null, durationValue: '0', durationUnit: 'day', expected: 'Duration must be greater than zero' },
+      { startTime: null, durationValue: 'abc', durationUnit: 'hour', expected: 'Duration must be a valid number' },
+      // Invalid unit
+      { startTime: null, durationValue: '5', durationUnit: 'invalid', expected: 'Invalid duration unit' },
+      // Invalid start time
+      { startTime: NOW, durationValue: '1', durationUnit: 'hour', expected: 'Start time must be at least 60 seconds from now' },
+      { startTime: NOW - 1, durationValue: '24', durationUnit: 'hour', expected: 'Start time must be at least 60 seconds from now' },
+    ];
+
+    for (const { startTime, durationValue, durationUnit, expected } of testCases) {
+      expect(validateEndTime(startTime, durationValue, durationUnit)).toBe(expected);
+    }
+  });
+
+  it('should not be affected by wall-clock drift during validation', () => {
+    // Even with time progression during validation, the result should be consistent
+    const result1 = validateEndTime(null, '1', 'hour');
+    // Simulate time advancing 30 seconds
+    vi.setSystemTime(new Date((NOW + 30) * 1000));
+    const result2 = validateEndTime(null, '1', 'hour');
+    expect(result1).toBe(result2);
+  });
+});
+
+describe('durationToSeconds', () => {
+  it('should convert hours correctly', () => {
+    expect(durationToSeconds(2, 'hour')).toBe(7200);
+  });
+
+  it('should convert days correctly', () => {
+    expect(durationToSeconds(1, 'day')).toBe(86400);
+  });
+
+  it('should convert weeks correctly', () => {
+    expect(durationToSeconds(1, 'week')).toBe(604800);
+  });
+
+  it('should convert months correctly', () => {
+    expect(durationToSeconds(1, 'month')).toBe(2592000);
+  });
+
+  it('should convert years correctly', () => {
+    expect(durationToSeconds(1, 'year')).toBe(31536000);
+  });
+
+  it('should handle fractional values', () => {
+    expect(durationToSeconds(0.5, 'hour')).toBe(1800);
+    expect(durationToSeconds(2.5, 'day')).toBe(216000);
+  });
+});
+
+describe('formatEndTime', () => {
+  it('should format a timestamp correctly', () => {
+    const timestamp = 1705315200; // Jan 15, 2024 12:00:00 UTC
+    const formatted = formatEndTime(timestamp);
+    expect(formatted).toContain('2024');
+    expect(formatted).toContain('UTC');
+  });
+});
+
+describe('getRelativeTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW * 1000));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should return "in the past" for past timestamps', () => {
+    expect(getRelativeTime(NOW - 5)).toBe('in the past');
+  });
+
+  it('should return minutes for near-future timestamps', () => {
+    expect(getRelativeTime(NOW + 120)).toBe('in 2 minutes');
+  });
+
+  it('should return hours for timestamps hours away', () => {
+    expect(getRelativeTime(NOW + 7200)).toBe('in 2 hours');
+  });
+
+  it('should return days for timestamps days away', () => {
+    expect(getRelativeTime(NOW + 172800)).toBe('in 2 days');
+  });
+
+  it('should return "in less than a minute" for very near time', () => {
+    expect(getRelativeTime(NOW + 30)).toBe('in less than a minute');
+  });
+});

--- a/apps/web/src/lib/__tests__/stream-validation.test.ts
+++ b/apps/web/src/lib/__tests__/stream-validation.test.ts
@@ -151,10 +151,8 @@ describe('validateEndTime', () => {
     expect(validateEndTime(null, '1', 'hour')).toBeNull();
   });
 
-  it('should accept null startTime with a short valid duration (1 minute)', () => {
-    // effective start = NOW + 60, endTime = NOW + 60 + 60 = NOW + 120 >= NOW + 60 ✓
-    // The "hour" unit makes 1 hour = 3600s, so this is fine
-    expect(validateEndTime(null, '1', 'hour')).toBeNull();
+  it('should accept a duration close to the minimum allowed unit (1 day)', () => {
+    expect(validateEndTime(null, '1', 'day')).toBeNull();
   });
 
   it('should accept an explicit valid startTime (now+60) with a regular duration', () => {

--- a/apps/web/src/lib/stream-validation.ts
+++ b/apps/web/src/lib/stream-validation.ts
@@ -16,6 +16,42 @@ const DURATION_MULTIPLIERS = {
 export type DurationUnit = keyof typeof DURATION_MULTIPLIERS;
 
 /**
+ * Minimum offset in seconds from current time that a start time must be.
+ * This ensures the stream never starts in the past after on-chain latency.
+ */
+export const MIN_START_TIME_OFFSET_SECONDS = 60;
+
+/**
+ * Get the earliest allowed start time (now + offset).
+ * @returns Unix timestamp in seconds
+ */
+export function getMinStartTime(): number {
+  return Math.floor(Date.now() / 1000) + MIN_START_TIME_OFFSET_SECONDS;
+}
+
+/**
+ * Validate that an explicitly-provided start time is at least
+ * `MIN_START_TIME_OFFSET_SECONDS` from now. When `startTime` is null
+ * (i.e. no explicit start time was selected), validation is skipped
+ * because the form defaults to the earliest allowed time.
+ * @param startTime - Start timestamp in seconds, or null if not explicitly set
+ * @returns Error message if invalid, null if valid or no explicit start time
+ */
+export function validateStartTime(startTime: number | null): string | null {
+  // Null means no explicit start time picked; nothing to validate
+  if (startTime === null) {
+    return null;
+  }
+
+  const minStart = getMinStartTime();
+  if (startTime < minStart) {
+    return "Start time must be at least 60 seconds from now";
+  }
+
+  return null;
+}
+
+/**
  * Convert duration value and unit to seconds
  */
 export function durationToSeconds(value: number, unit: DurationUnit): number {
@@ -23,8 +59,10 @@ export function durationToSeconds(value: number, unit: DurationUnit): number {
 }
 
 /**
- * Calculate stream end timestamp
- * @param startTime - Start timestamp in seconds (defaults to now)
+ * Calculate stream end timestamp.
+ * When startTime is null the effective start is `getMinStartTime()`,
+ * ensuring the stream never appears to start in the past.
+ * @param startTime - Start timestamp in seconds, or null to use min allowed start
  * @param durationValue - Duration value
  * @param durationUnit - Duration unit
  * @returns End timestamp in seconds
@@ -34,16 +72,16 @@ export function calculateEndTime(
   durationValue: number,
   durationUnit: DurationUnit
 ): number {
-  const start = startTime || Math.floor(Date.now() / 1000);
+  const start = startTime ?? getMinStartTime();
   const durationSeconds = durationToSeconds(durationValue, durationUnit);
   return start + durationSeconds;
 }
 
 /**
- * Validate that the stream end time is in the future
- * @param startTime - Start timestamp in seconds (defaults to now)
- * @param durationValue - Duration value
- * @param durationUnit - Duration unit
+ * Validate that the stream end time is at least 60 seconds from now.
+ * @param startTime - Start timestamp in seconds, or null to use min allowed start
+ * @param durationValue - Duration value string
+ * @param durationUnit - Duration unit string
  * @returns Error message if invalid, null if valid
  */
 export function validateEndTime(
@@ -53,35 +91,34 @@ export function validateEndTime(
 ): string | null {
   // Parse duration value
   const duration = parseInt(durationValue);
-  
+
   if (isNaN(duration)) {
     return "Duration must be a valid number";
   }
-  
+
   if (duration <= 0) {
     return "Duration must be greater than zero";
   }
-  
+
   // Validate duration unit
   if (!isDurationUnit(durationUnit)) {
     return "Invalid duration unit";
   }
-  
-  // Calculate end time
+
+  // Validate start time if it was explicitly provided
+  const startTimeError = validateStartTime(startTime);
+  if (startTimeError) {
+    return startTimeError;
+  }
+
+  // Calculate end time and check it meets the minimum offset
   const endTime = calculateEndTime(startTime, duration, durationUnit);
-  const now = Math.floor(Date.now() / 1000);
-  
-  // Check if end time is in the past
-  if (endTime <= now) {
-    return "Stream end time must be in the future";
+  const minEndTime = getMinStartTime();
+
+  if (endTime <= minEndTime) {
+    return "Stream end time must be at least 60 seconds from now";
   }
-  
-  // Warn if duration is very short (less than 1 minute)
-  const durationSeconds = durationToSeconds(duration, durationUnit);
-  if (durationSeconds < 60) {
-    return "Duration is too short (minimum 1 minute recommended)";
-  }
-  
+
   return null;
 }
 
@@ -99,7 +136,7 @@ function isDurationUnit(unit: string): unit is DurationUnit {
  */
 export function formatEndTime(timestamp: number): string {
   const date = new Date(timestamp * 1000);
-  
+
   return date.toLocaleString('en-US', {
     timeZone: 'UTC',
     year: 'numeric',
@@ -120,24 +157,24 @@ export function formatEndTime(timestamp: number): string {
 export function getRelativeTime(timestamp: number): string {
   const now = Math.floor(Date.now() / 1000);
   const diff = timestamp - now;
-  
+
   if (diff < 0) {
     return "in the past";
   }
-  
+
   const minutes = Math.floor(diff / 60);
   const hours = Math.floor(diff / 3600);
   const days = Math.floor(diff / 86400);
   const weeks = Math.floor(diff / 604800);
   const months = Math.floor(diff / 2592000);
   const years = Math.floor(diff / 31536000);
-  
+
   if (years > 0) return `in ${years} year${years !== 1 ? 's' : ''}`;
   if (months > 0) return `in ${months} month${months !== 1 ? 's' : ''}`;
   if (weeks > 0) return `in ${weeks} week${weeks !== 1 ? 's' : ''}`;
   if (days > 0) return `in ${days} day${days !== 1 ? 's' : ''}`;
   if (hours > 0) return `in ${hours} hour${hours !== 1 ? 's' : ''}`;
   if (minutes > 0) return `in ${minutes} minute${minutes !== 1 ? 's' : ''}`;
-  
+
   return "in less than a minute";
 }


### PR DESCRIPTION
Closes #398 

Add validateStartTime() and getMinStartTime() to stream-validation.ts - Update calculateEndTime() to use getMinStartTime() when startTime is null - Update validateEndTime() to reject explicit start times < now + 60s - Update CreatePaymentStream.tsx fee estimation to use now + 60s start time - Write comprehensive unit tests covering success, failure, and edge cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enforcement that stream start times must be at least 60 seconds in the future.
  * Updated end-time calculations and validation to use a consistent minimum start-time buffer.
* **Bug Fixes**
  * Improved payment stream creation fee estimates by applying the same 60-second buffered start time.
* **Tests**
  * Adjusted and expanded end-time validation test coverage around minimum duration constraints and timing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->