### PR TITLE
fix: show Confirming... badge for unconfirmed stream status

### DIFF
--- a/apps/web/src/components/modules/payment-stream/streamColumns.tsx
+++ b/apps/web/src/components/modules/payment-stream/streamColumns.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { Loader2 } from "lucide-react";
 import { sliceAddress } from "@/lib/utils";
 import { format } from "date-fns";
 import { ColumnDef } from "@tanstack/react-table";
@@ -18,6 +19,8 @@ const getStatusColor = (status: string) => {
             return "bg-orange-500";
         case "completed":
             return "bg-gray-500";
+        case "confirming":
+            return "bg-amber-400";
         default:
             return "bg-gray-500";
     }
@@ -82,7 +85,14 @@ export const streamColumns: ColumnDef<StreamRecord>[] = [
         cell: ({ row }) => {
             const stream = row.original;
             const now = Date.now();
-            const effectiveStatus = now > stream.endTime ? "completed" : stream.status;
+            // Don't apply time-based status overrides while the stream is still
+            // being confirmed on-chain — the end time may not be meaningful yet.
+            const isConfirming = stream.status?.toLowerCase() === "confirming";
+            const effectiveStatus = isConfirming
+                ? "confirming"
+                : now > stream.endTime
+                ? "completed"
+                : stream.status;
             return (
                 <div className="min-w-[150px]">
                     <StreamProgressBar
@@ -115,7 +125,12 @@ export const streamColumns: ColumnDef<StreamRecord>[] = [
             const endTime = row.getValue("endTime") as number;
             const status = row.original.status;
             const now = Date.now();
-            const effectiveStatus = now > endTime ? "completed" : status;
+            const isConfirming = status?.toLowerCase() === "confirming";
+            const effectiveStatus = isConfirming
+                ? "confirming"
+                : now > endTime
+                ? "completed"
+                : status;
             const formattedDate = format(new Date(endTime), "MMM dd, yyyy HH:mm");
             return (
                 <div className="flex flex-col items-center space-y-1">
@@ -131,11 +146,31 @@ export const streamColumns: ColumnDef<StreamRecord>[] = [
         cell: ({ row }) => {
             const endTime = row.original.endTime;
             const currentTime = Date.now();
+            const rawStatus = row.getValue("status") as string;
 
-            const status =
-                currentTime > endTime
-                    ? "completed"
-                    : (row.getValue("status") as string);
+            // A stream pending on-chain confirmation gets a distinct "Confirming..."
+            // badge so users can tell it apart from an already-Active stream.
+            const isConfirming = rawStatus?.toLowerCase() === "confirming";
+
+            const status = isConfirming
+                ? "confirming"
+                : currentTime > endTime
+                ? "completed"
+                : rawStatus;
+
+            if (isConfirming) {
+                return (
+                    <div className="flex justify-center items-center gap-1.5">
+                        <Loader2
+                            className="size-3.5 text-amber-400 animate-spin shrink-0"
+                            aria-hidden="true"
+                        />
+                        <span className="text-amber-300 font-medium animate-pulse whitespace-nowrap">
+                            Confirming...
+                        </span>
+                    </div>
+                );
+            }
 
             return (
                 <div className="flex justify-center items-center">

--- a/apps/web/src/lib/validations.ts
+++ b/apps/web/src/lib/validations.ts
@@ -12,7 +12,12 @@ export interface StreamRecord {
   withdrawnAmount: string
   startTime: number
   endTime: number
-  status: "Active" | "Paused" | "Canceled" | "Completed"
+  /**
+   * The on-chain lifecycle status of this stream.
+   * "Confirming" is a transient client-side state used while the creation
+   * transaction is still pending confirmation on the Stellar network.
+   */
+  status: "Active" | "Paused" | "Canceled" | "Completed" | "Confirming"
   cancelable: boolean
   transferable: boolean
   delegateAddress?: string | null


### PR DESCRIPTION
A newly created stream was visually indistinguishable from an Active stream while its creation transaction was still pending on the Stellar network. Users had no way to know the stream was not yet confirmed.

Changes:
- validations.ts: extend StreamRecord.status union with "Confirming" as a recognised transient client-side state
- streamColumns.tsx: add confirming case to getStatusColor() (amber)
- streamColumns.tsx: status cell renders an amber Loader2 spinner + pulsing "Confirming..." label instead of the standard dot badge when status is "confirming"
- streamColumns.tsx: progress and endTime columns guard against time-based status overrides (completed) while status is confirming so that the pending state is preserved end-to-end across all columns

StreamActionsCell already gates manage actions on Active/Paused only, so no changes are needed there — confirming streams correctly show only the read-only explorer/copy actions.

Closes #421