### PR TITLE
fix(#424): add tooltip explaining non-cancelable stream status

### DIFF
--- a/apps/web/src/components/modules/payment-stream/StreamActionsCell.tsx
+++ b/apps/web/src/components/modules/payment-stream/StreamActionsCell.tsx
@@ -20,6 +20,11 @@ import {
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { StreamRecord } from "@/lib/validations";
 import { STELLAR_EXPERT_URL } from "@/lib/constants";
 import { WithdrawStreamModal } from "./WithdrawStreamModal";
@@ -166,14 +171,31 @@ export default function StreamActionsCell({ stream }: StreamActionsCellProps) {
                         </DropdownMenuItem>
                     )}
 
-                    {isSender && (isActive || isPaused) && stream.cancelable && (
-                        <DropdownMenuItem
-                            className="cursor-pointer text-red-500 focus:text-red-500 focus:bg-red-500/10"
-                            onClick={handleCancel}
-                        >
-                            <XCircle className="mr-2 h-4 w-4" />
-                            Cancel Stream
-                        </DropdownMenuItem>
+                    {isSender && (isActive || isPaused) && (
+                        stream.cancelable ? (
+                            <DropdownMenuItem
+                                className="cursor-pointer text-red-500 focus:text-red-500 focus:bg-red-500/10"
+                                onClick={handleCancel}
+                            >
+                                <XCircle className="mr-2 h-4 w-4" />
+                                Cancel Stream
+                            </DropdownMenuItem>
+                        ) : (
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <DropdownMenuItem
+                                        className="text-red-500/50 cursor-not-allowed"
+                                        disabled
+                                    >
+                                        <XCircle className="mr-2 h-4 w-4" />
+                                        Cancel Stream
+                                    </DropdownMenuItem>
+                                </TooltipTrigger>
+                                <TooltipContent side="left">
+                                    This stream was configured as non-cancelable
+                                </TooltipContent>
+                            </Tooltip>
+                        )
                     )}
 
                     {isSender && (


### PR DESCRIPTION
When a stream has cancelable=false, show the 'Cancel Stream' menu item in a disabled state with a tooltip: 'This stream was configured as non-cancelable'. Previously the item was hidden entirely, giving users no indication of why the action was unavailable.

- Import Tooltip, TooltipTrigger, TooltipContent from ui/tooltip
- Replace conditional that hid the item with a branching render: cancelable → active item; !cancelable → disabled item + tooltip

closes #424 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The Cancel Stream option is now consistently visible for active or paused sender streams.
  * Non-cancelable streams display a disabled Cancel Stream option with an explanation of why cancellation is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->