### PR TITLE
fix(#423): wrap DropdownMenuContent in explicit DropdownMenuPortal

### DIFF
--- a/apps/web/src/components/modules/payment-stream/StreamActionsCell.tsx
+++ b/apps/web/src/components/modules/payment-stream/StreamActionsCell.tsx
@@ -16,6 +16,7 @@ import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
+    DropdownMenuPortal,
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
@@ -125,6 +126,7 @@ export default function StreamActionsCell({ stream }: StreamActionsCellProps) {
                         <MoreHorizontal className="h-4 w-4 text-white" aria-hidden="true" />
                     </Button>
                 </DropdownMenuTrigger>
+                <DropdownMenuPortal>
                 <DropdownMenuContent align="end">
                     {isRecipient && isActive && (
                         <DropdownMenuItem
@@ -203,6 +205,7 @@ export default function StreamActionsCell({ stream }: StreamActionsCellProps) {
                         Copy Stream ID
                     </DropdownMenuItem>
                 </DropdownMenuContent>
+                </DropdownMenuPortal>
             </DropdownMenu>
 
             <WithdrawStreamModal


### PR DESCRIPTION
The row-actions dropdown was clipping underneath the table's overflow container. Adding an explicit DropdownMenuPortal around DropdownMenuContent in StreamActionsCell ensures the dropdown renders at the document root, escaping any overflow:hidden or overflow:auto ancestors in StreamsTable.

- Import DropdownMenuPortal from ui/dropdown-menu
- Wrap DropdownMenuContent with DropdownMenuPortal inside the DropdownMenu

closes #423 