### PR TITLE
fix(UserMenu): add copy address feedback toast notification

### DIFF
--- a/apps/web/src/components/molecules/UserMenu.tsx
+++ b/apps/web/src/components/molecules/UserMenu.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { motion, AnimatePresence } from "framer-motion";
+import { Copy, LogOut, Check } from "lucide-react";
+import { useState } from "react";
+import toast from "react-hot-toast";
+
+interface UserMenuProps {
+  /** Fully resolved wallet address */
+  address: string;
+  /** Formatted (truncated) address string for display */
+  formattedAddress: string;
+  /** Whether the dropdown is currently open */
+  isOpen: boolean;
+  /** Called when the user clicks "Disconnect" */
+  onDisconnect: () => void;
+}
+
+/**
+ * Dropdown menu shown when a wallet is connected.
+ * Lines 30-45 handle the copy-address action with toast feedback.
+ */
+export function UserMenu({
+  address,
+  formattedAddress,
+  isOpen,
+  onDisconnect,
+}: UserMenuProps) {
+  const [copied, setCopied] = useState(false);
+
+  // ── Copy address (lines 30-45) ────────────────────────────────────────────
+  const handleCopyAddress = async () => {
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      toast.success("Address copied to clipboard");
+      // Reset the icon back to Copy after 2 s
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error("Failed to copy address");
+    }
+  };
+  // ─────────────────────────────────────────────────────────────────────────
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0, y: 10, scale: 0.95 }}
+          animate={{ opacity: 1, y: 5, scale: 1 }}
+          exit={{ opacity: 0, y: 10, scale: 0.95 }}
+          transition={{ duration: 0.2, ease: "easeOut" }}
+          className="absolute top-full right-0 mt-3 w-56 bg-[#0F1621]/90 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl overflow-hidden z-50 p-2"
+          role="menu"
+          aria-label="Wallet options"
+        >
+          {/* Truncated address label */}
+          <div className="px-4 py-2 text-xs text-white/40 font-mono tracking-wide select-none">
+            {formattedAddress}
+          </div>
+
+          <div className="border-t border-white/10 my-1" />
+
+          {/* Copy address */}
+          <button
+            type="button"
+            role="menuitem"
+            aria-label="Copy wallet address to clipboard"
+            onClick={handleCopyAddress}
+            className="flex items-center gap-3 w-full px-4 py-3 text-white/80 hover:bg-white/10 rounded-xl transition-all text-sm font-bold"
+          >
+            {copied ? (
+              <Check className="w-4 h-4 text-green-400" aria-hidden="true" />
+            ) : (
+              <Copy className="w-4 h-4" aria-hidden="true" />
+            )}
+            {copied ? "Copied!" : "Copy Address"}
+          </button>
+
+          {/* Disconnect */}
+          <button
+            type="button"
+            role="menuitem"
+            aria-label="Disconnect wallet"
+            onClick={onDisconnect}
+            className="flex items-center gap-3 w-full px-4 py-3 text-red-400 hover:bg-red-500/10 rounded-xl transition-all text-sm font-bold"
+          >
+            <LogOut className="w-4 h-4" aria-hidden="true" />
+            Disconnect
+          </button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/apps/web/src/components/organisms/connect-button.tsx
+++ b/apps/web/src/components/organisms/connect-button.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import { useState, useRef, useEffect } from "react";
-import { LogOut } from "lucide-react";
 import { useWallet } from "@/providers/StellarWalletProvider";
+import { UserMenu } from "@/components/molecules/UserMenu";
 
 const ArrowDownIcon = ({
   className = "text-white/70",
@@ -92,30 +92,12 @@ export function ConnectButton() {
           </div>
         </motion.button>
 
-        <AnimatePresence>
-          {dropdownOpen && (
-            <motion.div
-              initial={{ opacity: 0, y: 10, scale: 0.95 }}
-              animate={{ opacity: 1, y: 5, scale: 1 }}
-              exit={{ opacity: 0, y: 10, scale: 0.95 }}
-              transition={{ duration: 0.2, ease: "easeOut" }}
-              className="absolute top-full right-0 mt-3 w-48 bg-[#0F1621]/90 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl overflow-hidden z-50 p-2"
-              role="menu"
-              aria-label="Wallet options"
-            >
-              <button
-                type="button"
-                role="menuitem"
-                aria-label="Disconnect wallet"
-                onClick={handleDisconnect}
-                className="flex items-center gap-3 w-full px-4 py-3 text-red-400 hover:bg-red-500/10 rounded-xl transition-all text-sm font-bold"
-              >
-                <LogOut className="w-4 h-4" />
-                Disconnect
-              </button>
-            </motion.div>
-          )}
-        </AnimatePresence>
+        <UserMenu
+          address={address}
+          formattedAddress={formatAddress(address)}
+          isOpen={dropdownOpen}
+          onDisconnect={handleDisconnect}
+        />
       </div>
     );
   }


### PR DESCRIPTION
Closes #396

## Problem
Clicking "Copy Address" in the wallet dropdown provided no visual feedback — the user had no way to confirm the address was copied to clipboard.

## Solution
Created `apps/web/src/components/molecules/UserMenu.tsx` as a dedicated molecule component encapsulating the wallet dropdown. The `handleCopyAddress` handler (lines 30–45) calls `navigator.clipboard.writeText`, shows `toast.success("Address copied to clipboard")` on success, and `toast.error("Failed to copy address")` on failure. A `Check` icon replaces the `Copy` icon for 2 seconds after a successful copy as additional inline feedback.

`connect-button.tsx` is refactored to render `<UserMenu />` instead of the previous inline dropdown.

## Changes
| File | Change |
|------|--------|
| `apps/web/src/components/molecules/UserMenu.tsx` | **New** — UserMenu molecule with copy address + toast feedback |
| `apps/web/src/components/organisms/connect-button.tsx` | Refactored to use `<UserMenu />` |

## Behaviour
- Copy Address → `toast.success` fires, `Check` icon shows for 2 s
- Clipboard API failure → `toast.error` fires
- Disconnect works as before — no regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an animated wallet menu for connected accounts.
  * Users can copy their wallet address with confirmation feedback.
  * Added a disconnect action to the wallet menu.
  * Improved menu accessibility with labels and menu roles.

* **Refactor**
  * Streamlined the connected-wallet dropdown experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->