### PR TITLE
fix(stream-validation): add StrKey contract ID format validation

### DIFF
--- a/apps/web/src/components/modules/payment-stream/CreatePaymentStream.tsx
+++ b/apps/web/src/components/modules/payment-stream/CreatePaymentStream.tsx
@@ -11,7 +11,7 @@ import { PaymentStreamConfirmationModal } from "./PaymentStreamConfirmationModal
 import { capitalizeWord } from "@/lib/utils";
 import { SUPPORTED_TOKENS, PaymentStreamFormData } from "@/lib/validations";
 import { StellarService } from "@/lib/stellar";
-import { validateEndTime } from "@/lib/stream-validation";
+import { validateEndTime, validateContractId } from "@/lib/stream-validation";
 import { useDebouncedCallback } from "@/hooks/use-debounce-callback";
 import { useBalanceValidation } from "@/hooks/use-balance-validation";
 import { useUnsavedChanges } from "@/hooks/use-unsaved-changes";
@@ -156,6 +156,14 @@ const CreatePaymentStream = () => {
     }
     if (!StellarService.validateStellarAddress(streamData.recipient)) {
       toast.error("Invalid Stellar address");
+      return;
+    }
+
+    // Validate token contract ID (must be 'native' for XLM or a valid StrKey contract address)
+    const selectedTokenMeta = SUPPORTED_TOKENS.find((t) => t.value === streamData.token);
+    const tokenAddress = selectedTokenMeta?.address;
+    if (!tokenAddress || (tokenAddress !== "native" && !validateContractId(tokenAddress))) {
+      toast.error("Invalid token: contract address is not a valid Stellar contract ID");
       return;
     }
     if (!streamData.amount || parseFloat(streamData.amount) <= 0) {

--- a/apps/web/src/lib/stream-validation.ts
+++ b/apps/web/src/lib/stream-validation.ts
@@ -2,6 +2,22 @@
  * Stream validation utilities for payment stream forms
  */
 
+import { StrKey } from "@stellar/stellar-sdk";
+
+/**
+ * Validate that a string is a valid Stellar contract ID (StrKey C... format)
+ * @param contractId - The contract address to validate
+ * @returns true if the address is a valid contract StrKey, false otherwise
+ */
+export function validateContractId(contractId: string): boolean {
+  if (!contractId || typeof contractId !== "string") return false;
+  try {
+    return StrKey.isValidContract(contractId);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Duration unit multipliers in seconds
  */

--- a/apps/web/src/lib/validations.ts
+++ b/apps/web/src/lib/validations.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
 import { StellarService } from "./stellar"
+import { validateContractId } from "./stream-validation"
 
 // Stream record type for display
 export interface StreamRecord {
@@ -26,7 +27,11 @@ export const paymentStreamSchema = z.object({
   
   token: z
     .string()
-    .min(1, "Token selection is required"),
+    .min(1, "Token selection is required")
+    .refine(
+      (val) => val === "native" || validateContractId(val),
+      "Invalid token: must be 'native' or a valid Stellar contract ID"
+    ),
   
   totalAmount: z
     .string()


### PR DESCRIPTION
- Add validateContractId() to stream-validation.ts using StrKey.isValidContract
- Apply contract ID validation to token field in paymentStreamSchema (validations.ts)
- Guard token contract address in CreatePaymentStream handleFormSubmit
- Native XLM token ('native') is correctly exempted from contract ID check

Closes #379 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment stream validation to reject invalid Stellar token contract IDs.
  * Native XLM payments continue to be supported without a contract ID.
  * Added clearer error messaging when an invalid token is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->