### PR TITLE
fix(web): resolve issues #406, #407, #408, and #409

### DIFF
--- a/apps/web/src/components/modules/payment-stream/PaymentStreamConfirmationModal.tsx
+++ b/apps/web/src/components/modules/payment-stream/PaymentStreamConfirmationModal.tsx
@@ -38,9 +38,19 @@ export function PaymentStreamConfirmationModal({
     onConfirm(data)
   }
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !isSubmitting) {
+      e.preventDefault()
+      handleConfirm()
+    }
+  }
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[94vw] max-w-2xl sm:w-full max-h-[85vh] overflow-y-auto p-4 sm:p-6">
+      <DialogContent 
+        className="w-[94vw] max-w-2xl sm:w-full max-h-[85vh] overflow-y-auto p-4 sm:p-6"
+        onKeyDown={handleKeyDown}
+      >
         <DialogHeader>
           <DialogTitle>Confirm Payment Stream</DialogTitle>
           <DialogDescription>

--- a/apps/web/src/components/modules/payment-stream/PaymentStreamForm.tsx
+++ b/apps/web/src/components/modules/payment-stream/PaymentStreamForm.tsx
@@ -162,7 +162,6 @@ export function PaymentStreamForm({
                 className={`border-zinc-700 bg-zinc-800 rounded h-12 placeholder:text-zinc-500 text-white ${
                   endTimeValidation.error ? "border-red-500" : ""
                 }`}
-                maxLength={streamData.duration === "hour" ? 1 : 3}
                 placeholder="Value eg. 1"
                 value={streamData.durationValue}
                 onChange={(e) =>
@@ -171,7 +170,14 @@ export function PaymentStreamForm({
               />
               <AppSelect
                 className="h-12"
-                setValue={(value) => handleStreamDataChange("duration", value)}
+                setValue={(value) => {
+                  setStreamData((prev) => ({
+                    ...prev,
+                    duration: value,
+                    durationValue: prev.durationValue,
+                  }));
+                }}
+                value={streamData.duration}
                 options={durationOptions}
                 placeholder={streamData.duration || "Pick a duration"}
               />

--- a/apps/web/src/hooks/use-unsaved-changes.ts
+++ b/apps/web/src/hooks/use-unsaved-changes.ts
@@ -14,11 +14,14 @@ export function useUnsavedChanges(isDirty: boolean, message: string = DEFAULT_WA
     }
 
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!isDirty) return;
       event.preventDefault();
       event.returnValue = '';
     };
 
     const handleDocumentClick = (event: MouseEvent) => {
+      if (!isDirty) return;
+
       const target = event.target as Element | null;
       const anchor = target?.closest('a[href]') as HTMLAnchorElement | null;
 
@@ -59,6 +62,7 @@ export function useUnsavedChanges(isDirty: boolean, message: string = DEFAULT_WA
     };
 
     const handlePopState = () => {
+      if (!isDirty) return;
       if (!window.confirm(message)) {
         window.history.go(1);
       }

--- a/apps/web/src/lib/validations.ts
+++ b/apps/web/src/lib/validations.ts
@@ -22,7 +22,7 @@ export const paymentStreamSchema = z.object({
   recipientAddress: z
     .string()
     .min(1, "Recipient address is required")
-    .refine((address) => StellarService.validateStellarAddress(address), "Invalid Stellar address format"),
+    .refine((address) => StellarService.validateStellarAddress(address), "Please enter a valid Stellar public key"),
   
   token: z
     .string()


### PR DESCRIPTION
1. Fix #406 - Bind Enter key to confirmation modal submit:
   - What was done: Added an Enter keydown event listener to PaymentStreamConfirmationModal.
   - How it was done: Defined handleKeyDown to intercept Enter key events on DialogContent when isSubmitting is false, calling handleConfirm() and preventing default event behavior.
   - Closes #406

2. Fix #407 - Improve StrKey error message copy for invalid addresses:
   - What was done: Updated error message copy for invalid Stellar address formats in form validation schemas.
   - How it was done: Changed the refine error message in paymentStreamSchema inside apps/web/src/lib/validations.ts from 'Invalid Stellar address format' to 'Please enter a valid Stellar public key'.
   - Closes #407

3. Fix #408 - Condition unsaved changes warning strictly on form isDirty flag:
   - What was done: Ensured navigation warning dialogs only trigger when the form is dirty.
   - How it was done: Updated handleBeforeUnload, handleDocumentClick, and handlePopState handlers in use-unsaved-changes.ts with explicit checks (if (!isDirty) return;) before evaluating navigation or showing prompts.
   - Closes #408

4. Fix #409 - Retain entered duration value on unit change:
   - What was done: Preserved numerical duration input value when changing duration units.
   - How it was done: Updated AppSelect setValue callback in PaymentStreamForm.tsx to preserve prev.durationValue state when updating duration unit, and removed overly restrictive maxLength input constraints.
   - Closes #409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pressing **Enter** now confirms payment stream details directly from the confirmation dialog.

- **Bug Fixes**
  - Improved streaming duration controls to preserve entered values when changing units.
  - Duration validation now provides clearer visual feedback.
  - Unsaved-changes warnings no longer appear when there are no edits.
  - Updated the Stellar address validation message to clearly request a valid public key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->