### PR TITLE
fix(web): trim whitespace on pasted recipient address input

### DIFF
--- a/apps/web/src/components/molecules/RecipientRow.tsx
+++ b/apps/web/src/components/molecules/RecipientRow.tsx
@@ -58,10 +58,11 @@ export function RecipientRow({
     : null;
 
   const handleAddressChange = (value: string) => {
+    const trimmed = value.trim();
     onChange({
-      address: value,
-      isValid: !validateStellarAddress(value),
-      validationError: validateStellarAddress(value) || undefined,
+      address: trimmed,
+      isValid: !validateStellarAddress(trimmed),
+      validationError: validateStellarAddress(trimmed) || undefined,
     });
   };
 


### PR DESCRIPTION
PR #439 

## Description

Pasting a Stellar address with trailing whitespace (e.g., `GB... ` or `\nGB...`) into the recipient address input causes validation to fail because `validateStellarAddress` receives the un-trimmed string.

This fix trims whitespace from the address value at the input handler level in `RecipientRow`, so the pasted/typed value is sanitized before validation and state storage.

## Changes

- **`apps/web/src/components/molecules/RecipientRow.tsx`** — `handleAddressChange` now calls `.trim()` on the input value before passing it to `onChange`.

## Testing

- All existing tests in `use-distribution-state.test.ts`, `stellar-validation.test.ts`, and `amount-validation.test.ts` pass.
- Manual verification: pasting `GABC... \n` no longer triggers a validation error; the whitespace is stripped.

Closes #439 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recipient addresses are now automatically trimmed of leading and trailing spaces.
  * Address validation now accurately reflects the cleaned input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->