### PR TITLE
fix(web): scope localStorage key and refresh expired quote on rate timer end

### DIFF
--- a/apps/web/e2e/helpers/mock-wallet.ts
+++ b/apps/web/e2e/helpers/mock-wallet.ts
@@ -9,7 +9,7 @@ export const MOCK_ADDRESS = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 export async function injectConnectedWallet(page: Page, address = MOCK_ADDRESS) {
   await page.addInitScript((addr) => {
     localStorage.setItem('stellar_wallet_address', addr);
-    localStorage.setItem('stellar_wallet_id', 'freighter');
+    localStorage.setItem('@fundable/web:selected_wallet', 'freighter');
     localStorage.setItem('stellar_wallet_network', 'Test SDF Network ; September 2015');
   }, address);
 }
@@ -20,7 +20,7 @@ export async function injectConnectedWallet(page: Page, address = MOCK_ADDRESS) 
 export async function clearWalletState(page: Page) {
   await page.addInitScript(() => {
     localStorage.removeItem('stellar_wallet_address');
-    localStorage.removeItem('stellar_wallet_id');
+    localStorage.removeItem('@fundable/web:selected_wallet');
     localStorage.removeItem('stellar_wallet_network');
   });
 }

--- a/apps/web/src/app/(overview)/offramp/page.tsx
+++ b/apps/web/src/app/(overview)/offramp/page.tsx
@@ -200,6 +200,7 @@ export default function OfframpPage() {
                     formState={formState}
                     onClose={handleCloseQuoteModal}
                     onConfirm={handleConfirmBridge}
+                    onRefresh={handleProceedToConfirm}
                     isLoading={isLoading}
                     isSubmitting={bridgeGuard.isGuardActive}
                 />

--- a/apps/web/src/components/offramp/OfframpQuoteModal.tsx
+++ b/apps/web/src/components/offramp/OfframpQuoteModal.tsx
@@ -1,6 +1,6 @@
 "use client";
-  
-import React, { useCallback } from "react";
+
+import React, { useCallback, useEffect, useState } from "react";
 import {
     Dialog,
     DialogContent,
@@ -9,58 +9,138 @@ import {
     DialogDescription,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Loader2, X } from "lucide-react";
+import { Loader2, RefreshCw, Timer } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
-  
+
 import type { CreateOfframpResponse, OfframpFormState } from "@/types/offramp";
 import { getCurrencySymbol } from "@/types/offramp";
- 
+
 interface OfframpQuoteModalProps {
     isOpen: boolean;
     offrampData: CreateOfframpResponse["data"] | null;
     formState: OfframpFormState;
     onClose: () => void;
     onConfirm: () => void;
+    onRefresh: () => void;
     isLoading: boolean;
     isSubmitting?: boolean;
 }
- 
+
 export default function OfframpQuoteModal({
     isOpen,
     offrampData,
     formState,
     onClose,
     onConfirm,
+    onRefresh,
     isLoading,
     isSubmitting = false,
 }: OfframpQuoteModalProps) {
     const handleClose = useCallback(() => {
         if (!isLoading) onClose();
     }, [isLoading, onClose]);
- 
+
+    const [timeLeft, setTimeLeft] = useState<number | null>(null);
+    const [isExpired, setIsExpired] = useState(false);
+
+    useEffect(() => {
+        if (!offrampData?.expiresAt) {
+            setTimeLeft(null);
+            setIsExpired(false);
+            return;
+        }
+
+        const tick = () => {
+            const remaining = Math.floor(
+                (new Date(offrampData.expiresAt!).getTime() - Date.now()) / 1000,
+            );
+            if (remaining <= 0) {
+                setTimeLeft(0);
+                setIsExpired(true);
+                return;
+            }
+            setTimeLeft(remaining);
+            setIsExpired(false);
+        };
+
+        tick();
+        const intervalId = setInterval(tick, 1000);
+        return () => clearInterval(intervalId);
+    }, [offrampData?.expiresAt]);
+
     if (!isOpen) return null;
-  
+
     const isLoadingQuote = !offrampData;
-    const currencySymbol = offrampData ? getCurrencySymbol(offrampData.currency) : '';
+    const currencySymbol = offrampData
+        ? getCurrencySymbol(offrampData.currency)
+        : "";
     const parsedAmount = parseFloat(formState.amount);
-    const safeAmount = !formState.amount || isNaN(parsedAmount) ? null : parsedAmount;
-    const safeFiatAmount = offrampData && !isNaN(offrampData.fiatAmount) ? offrampData.fiatAmount.toLocaleString() : '--';
-  
+    const safeAmount =
+        !formState.amount || isNaN(parsedAmount) ? null : parsedAmount;
+    const safeFiatAmount =
+        offrampData && !isNaN(offrampData.fiatAmount)
+            ? offrampData.fiatAmount.toLocaleString()
+            : "--";
+
     return (
         <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-            <DialogContent 
-                className="bg-fundable-mid-dark border border-fundable-purple p-6 w-full max-w-md mx-4 relative"
-            >
+            <DialogContent className="bg-fundable-mid-dark border border-fundable-purple p-6 w-full max-w-md mx-4 relative">
                 <DialogHeader>
-                    <DialogTitle id="offramp-quote-title" className="text-xl font-syne font-semibold text-white mb-6">
+                    <DialogTitle
+                        id="offramp-quote-title"
+                        className="text-xl font-syne font-semibold text-white mb-6"
+                    >
                         Confirm Offramp
                     </DialogTitle>
-                    <DialogDescription id="offramp-quote-desc" className="sr-only">
-                        Review the transaction breakdown and confirm your offramp request.
+                    <DialogDescription
+                        id="offramp-quote-desc"
+                        className="sr-only"
+                    >
+                        Review the transaction breakdown and confirm your
+                        offramp request.
                     </DialogDescription>
                 </DialogHeader>
-  
-                {isLoadingQuote ? (
+
+                {isExpired ? (
+                    <div className="space-y-4">
+                        <div className="bg-orange-500/10 border border-orange-500/30 rounded-lg p-6 text-center">
+                            <Timer className="h-10 w-10 text-orange-500 mx-auto mb-3" />
+                            <p className="text-orange-400 font-semibold text-lg">
+                                Quote Expired
+                            </p>
+                            <p className="text-fundable-light-grey text-sm mt-1">
+                                The rate quote has expired. Please fetch a new
+                                quote to continue.
+                            </p>
+                        </div>
+                        <div className="flex gap-4 mt-6">
+                            <Button
+                                onClick={onClose}
+                                variant="secondary"
+                                className="flex-1 bg-gray-800 hover:bg-gray-700 text-white border-none h-12"
+                            >
+                                Cancel
+                            </Button>
+                            <Button
+                                onClick={onRefresh}
+                                disabled={isLoading}
+                                className="flex-1 bg-gradient-to-r from-fundable-purple-2 to-purple-500 text-black h-12"
+                            >
+                                {isLoading ? (
+                                    <>
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                        Refreshing...
+                                    </>
+                                ) : (
+                                    <>
+                                        <RefreshCw className="mr-2 h-4 w-4" />
+                                        Get New Quote
+                                    </>
+                                )}
+                            </Button>
+                        </div>
+                    </div>
+                ) : isLoadingQuote ? (
                     <div className="space-y-4">
                         <div className="bg-fundable-dark p-4 rounded-lg">
                             <Skeleton className="h-4 w-20 mb-2 bg-fundable-light-grey" />
@@ -91,36 +171,75 @@ export default function OfframpQuoteModal({
                     </div>
                 ) : (
                     <div className="space-y-4">
+                        {/* Quote Expiry Countdown */}
+                        {timeLeft !== null && timeLeft <= 120 && (
+                            <div
+                                className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm ${
+                                    timeLeft <= 30
+                                        ? "bg-red-500/10 text-red-400"
+                                        : "bg-orange-500/10 text-orange-400"
+                                }`}
+                            >
+                                <Timer className="h-4 w-4" />
+                                <span className="font-medium">
+                                    {timeLeft <= 30
+                                        ? "Quote expiring soon"
+                                        : "Quote expires in"}{" "}
+                                    <span className="font-bold">
+                                        {timeLeft}s
+                                    </span>
+                                </span>
+                            </div>
+                        )}
+
                         <div className="bg-fundable-dark p-4 rounded-lg">
-                            <p className="text-fundable-light-grey text-sm">You Send</p>
-                             <p className="text-white text-xl font-semibold">
-                                 {safeAmount !== null ? safeAmount.toFixed(4) : '--'} {formState.token}
-                             </p>
-                        </div>
-  
-                        <div className="bg-fundable-dark p-4 rounded-lg">
-                            <p className="text-fundable-light-grey text-sm">Total Payout</p>
-                            <p className="text-white text-2xl font-bold">
-                                 {currencySymbol}{safeFiatAmount}
+                            <p className="text-fundable-light-grey text-sm">
+                                You Send
+                            </p>
+                            <p className="text-white text-xl font-semibold">
+                                {safeAmount !== null
+                                    ? safeAmount.toFixed(4)
+                                    : "--"}{" "}
+                                {formState.token}
                             </p>
                         </div>
-  
+
+                        <div className="bg-fundable-dark p-4 rounded-lg">
+                            <p className="text-fundable-light-grey text-sm">
+                                Total Payout
+                            </p>
+                            <p className="text-white text-2xl font-bold">
+                                {currencySymbol}
+                                {safeFiatAmount}
+                            </p>
+                        </div>
+
                         <div className="space-y-3 bg-fundable-dark/50 p-4 rounded-lg border border-gray-800 text-sm">
                             <div className="flex justify-between items-center text-xs text-fundable-light-grey uppercase tracking-wider mb-1">
                                 <span>Transaction Breakdown</span>
                             </div>
                             <div className="flex justify-between">
-                                <span className="text-fundable-light-grey">Reference</span>
-                                <span className="text-white text-[10px] font-mono opacity-80">{offrampData.reference}</span>
+                                <span className="text-fundable-light-grey">
+                                    Reference
+                                </span>
+                                <span className="text-white text-[10px] font-mono opacity-80">
+                                    {offrampData.reference}
+                                </span>
                             </div>
                         </div>
-  
+
                         <div className="bg-fundable-dark p-4 rounded-lg">
-                            <p className="text-fundable-light-grey text-sm mb-2">Bank Details</p>
-                            <p className="text-white font-medium">{formState.accountName}</p>
-                            <p className="text-white">{formState.accountNumber}</p>
+                            <p className="text-fundable-light-grey text-sm mb-2">
+                                Bank Details
+                            </p>
+                            <p className="text-white font-medium">
+                                {formState.accountName}
+                            </p>
+                            <p className="text-white">
+                                {formState.accountNumber}
+                            </p>
                         </div>
-  
+
                         <div className="flex gap-4 mt-6">
                             <Button
                                 onClick={onClose}
@@ -132,7 +251,7 @@ export default function OfframpQuoteModal({
                             </Button>
                             <Button
                                 onClick={onConfirm}
-                                disabled={isLoading || isSubmitting}
+                                disabled={isLoading || isSubmitting || isExpired}
                                 className="flex-1 bg-gradient-to-r from-fundable-purple-2 to-purple-500 text-black h-12"
                             >
                                 {isLoading || isSubmitting ? (

--- a/apps/web/src/providers/StellarWalletProvider.tsx
+++ b/apps/web/src/providers/StellarWalletProvider.tsx
@@ -69,7 +69,7 @@ export const StellarWalletProvider = ({
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>(() => {
     if (typeof window === 'undefined') return "idle";
     const savedAddress = safeGetItem("stellar_wallet_address");
-    const savedWalletId = safeGetItem("stellar_wallet_id");
+    const savedWalletId = safeGetItem("@fundable/web:selected_wallet");
     const savedNetwork = safeGetItem("stellar_wallet_network");
     console.log('Lazy init connectionStatus:', { savedAddress, savedWalletId, savedNetwork });
     if (savedAddress && isValidStellarAddress(savedAddress) && savedWalletId && savedNetwork === WalletNetwork.TESTNET) {
@@ -80,7 +80,7 @@ export const StellarWalletProvider = ({
   const [selectedWalletId, setSelectedWalletId] = useState<WalletId | null>(() => {
     if (typeof window === 'undefined') return null;
     const savedAddress = safeGetItem("stellar_wallet_address");
-    const savedWalletId = safeGetItem("stellar_wallet_id");
+    const savedWalletId = safeGetItem("@fundable/web:selected_wallet");
     const savedNetwork = safeGetItem("stellar_wallet_network");
     console.log('Lazy init selectedWalletId:', { savedWalletId, savedNetwork });
     if (savedNetwork === WalletNetwork.TESTNET && savedAddress && isValidStellarAddress(savedAddress)) {
@@ -109,14 +109,14 @@ export const StellarWalletProvider = ({
 
     // RESTORE SESSION
     const savedAddress = safeGetItem("stellar_wallet_address");
-    const savedWalletId = safeGetItem("stellar_wallet_id");
+    const savedWalletId = safeGetItem("@fundable/web:selected_wallet");
     const savedNetwork = safeGetItem("stellar_wallet_network");
 
     if (savedAddress && savedWalletId && savedNetwork === network) {
       if (!isValidStellarAddress(savedAddress)) {
         // Tampered or invalid address — clear storage and force reconnect
         safeRemoveItem("stellar_wallet_address");
-        safeRemoveItem("stellar_wallet_id");
+        safeRemoveItem("@fundable/web:selected_wallet");
         safeRemoveItem("stellar_wallet_network");
         setAddress(null);
         setSelectedWalletId(null);
@@ -141,7 +141,7 @@ export const StellarWalletProvider = ({
     setAddress(null);
     setSelectedWalletId(null);
     safeRemoveItem("stellar_wallet_address");
-    safeRemoveItem("stellar_wallet_id");
+    safeRemoveItem("@fundable/web:selected_wallet");
     safeRemoveItem("stellar_wallet_network");
     setConnectionStatus("idle");
   }, []);
@@ -228,7 +228,7 @@ export const StellarWalletProvider = ({
       setSelectedWalletId(walletId);
       setConnectionStatus("connected");
       safeSetItem("stellar_wallet_address", resolvedAddress);
-      safeSetItem("stellar_wallet_id", walletId);
+      safeSetItem("@fundable/web:selected_wallet", walletId);
       safeSetItem("stellar_wallet_network", network);
 
       // Sync with backend on new connection


### PR DESCRIPTION
## Overview

This PR addresses two Stellar Wave issues:

1. **Scoped localStorage key** — Prevents key collision across apps sharing the same origin by renaming the generic `stellar_wallet_id` key to `@fundable/web:selected_wallet`.

2. **Expired quote handling** — When the offramp rate quote timer expires, the modal no longer stays open with a stale rate. Instead it shows an expired-state UI and offers a "Get New Quote" button to re-fetch.

## Related Issue

Closes #395
Closes #441

## Changes

### Scoped localStorage key
* **[FIX]** `apps/web/src/providers/StellarWalletProvider.tsx`
  * Changed 6 occurrences of `stellar_wallet_id` to `@fundable/web:selected_wallet` to namespace the key under the `@fundable/web` package scope, preventing collisions with other apps on the same origin.

* **[FIX]** `apps/web/e2e/helpers/mock-wallet.ts`
  * Updated E2E helper to use the new scoped key name.

### Expired quote refresh
* **[MODIFY]** `apps/web/src/components/offramp/OfframpQuoteModal.tsx`
  * Added `onRefresh` prop for triggering a fresh quote fetch.
  * Added countdown timer derived from `offrampData.expiresAt` with visual warnings (orange at 2 min, red at 30 s).
  * When the quote expires, the confirm button is disabled and an expired-state UI is rendered with a "Get New Quote" button.

* **[MODIFY]** `apps/web/src/app/(overview)/offramp/page.tsx`
  * Passed `handleProceedToConfirm` as the `onRefresh` prop to the modal.

## Verification Results

```
pnpm test -- src/providers/ src/hooks/useOfframpBridge.test.ts
  23/23 passed

ESLint on changed files:
  No linter errors
```

| Acceptance Criteria | Status |
| --- | --- |
| localStorage key is scoped to `@fundable/web:selected_wallet` | All reads/writes/removes use the namespaced key |
| No regression in existing test suites | 23/23 related tests pass |
| Expired quote prompts user to re-fetch | Modal shows expired UI with "Get New Quote" button |
| Stale confirmations are prevented | Confirm button disabled when `isExpired` is true |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quote expiration tracking to off-ramp quotes.
  * Added warnings when quotes are nearing expiration.
  * Added an option to request a new quote after expiration.
  * Prevented confirmation of expired quotes.

* **Bug Fixes**
  * Improved wallet connection persistence and restoration across sessions.
  * Ensured disconnecting clears the saved wallet selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->