### PR TITLE
fix(DepositStreamModal): enforce positive amount validation for token deposits

### DIFF
--- a/apps/web/src/components/modules/payment-stream/DepositStreamModal.tsx
+++ b/apps/web/src/components/modules/payment-stream/DepositStreamModal.tsx
@@ -53,6 +53,12 @@ export function DepositStreamModal({
   }, [stream])
 
   const onSubmit = async (data: DepositStreamFormData) => {
+    const parsedAmount = parseFloat(data.amount)
+    if (isNaN(parsedAmount) || parsedAmount <= 0) {
+      notify.error("Deposit amount must be greater than zero")
+      return
+    }
+
     setIsSubmitting(true)
     try {
       const txHash = await StellarService.depositToStream(stream.id, data)
@@ -114,6 +120,7 @@ export function DepositStreamModal({
               <Input
                 id="deposit-amount"
                 type="number"
+                min="0"
                 step="0.0000001"
                 placeholder="0.00"
                 aria-label={`Deposit amount in ${stream.tokenSymbol}`}


### PR DESCRIPTION
## Overview

This PR enforces positive amount validation for token deposits in the DepositStreamModal to prevent users from submitting zero or negative deposit amounts into existing payment streams.

## Related Issue

Closes #419

## Changes

- **[ADD]** Explicit front-end guard in `onSubmit` handler — checks that `parseFloat(data.amount) > 0` and shows an error notification before proceeding with the deposit
- **[ADD]** `min="0"` HTML attribute on the number input element to prevent browsers from allowing negative values via the stepper/spinner

### Defense-in-depth validation layers

| Layer | Location | Validation |
|-------|----------|------------|
| Browser | Input `min="0"` attribute | Prevents negative/spinner values |
| Zod schema | `validations.ts` → `depositStreamSchema` | `.refine()` checks `parseFloat(val) > 0` |
| Component | `onSubmit` handler | Explicit guard with user-facing notification |
| Service | `stellar.ts` → `depositToStream()` | Rejects non-positive amounts with `Error` |

## Verification Results

TypeScript compiles without new errors. All 4 pre-existing test failures are unrelated (sanitize-error regex patterns, app-provider offline notification, stellar-service edge cases).

| Acceptance Criteria | Status |
| --- | --- |
| Zero deposits are rejected with a clear message | ✅ |
| Negative deposits are rejected with a clear message | ✅ |
| Valid positive deposits proceed as expected | ✅ |
| No regression in existing test suites | ✅ |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deposit amounts are now validated before submission.
  * Invalid or non-positive amounts display an error notification and cannot be submitted.
  * The amount field now enforces a minimum value of zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->