### PR TITLE
forward ARIA attributes to Radix Switch element

### DIFF
--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -5,12 +5,13 @@ export interface SwitchProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}
 
 const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(
-  ({ className, checked, ...props }, ref) => {
+  ({ className, checked, title, ...props }, ref) => {
     return (
       <label 
         className="relative inline-flex items-center cursor-pointer" 
         role="switch"
         aria-checked={checked}
+        title={title}
       >
         <input
           type="checkbox"


### PR DESCRIPTION
Closes #412 

The aria-checked attribute already properly set on the label element. Now the title attribute is also forwarded correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Switch controls now display their provided title text consistently when users hover over them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->