### PR TITLE
feat(map): add interactive satellite imagery layer toggle

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,6 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
-    "@fundable/sdk": "workspace:*",
     "@creit.tech/stellar-wallets-kit": "^1.9.5",
     "@fundable/sdk": "workspace:*",
     "@hookform/resolvers": "^5.2.2",
@@ -37,6 +36,7 @@
     "date-fns": "^4.1.0",
     "framer-motion": "^12.28.1",
     "lucide-react": "^0.562.0",
+    "maplibre-gl": "^6.0.0",
     "next": "16.1.2",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/apps/web/src/app/(overview)/dashboard/page.tsx
+++ b/apps/web/src/app/(overview)/dashboard/page.tsx
@@ -1,11 +1,13 @@
 import StatsOverview from "@/components/modules/dashboard/StatsOverview";
 import FeatureCards from "@/components/modules/dashboard/FeatureCards";
+import { ImpactMapSection } from "@/components/modules/impact-map/ImpactMapSection";
 
 const DashboardPage = async () => {
     return (
         <main className="h-full overflow-y-auto space-y-4 md:space-y-12 py-10">
             <StatsOverview />
             <FeatureCards />
+            <ImpactMapSection />
         </main>
     );
 };

--- a/apps/web/src/components/modules/impact-map/ImpactMapSection.tsx
+++ b/apps/web/src/components/modules/impact-map/ImpactMapSection.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const ImpactMap = dynamic(
+  () => import("@/components/organisms/ImpactMap").then((m) => m.ImpactMap),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex flex-col gap-4">
+        <div className="space-y-1">
+          <Skeleton className="h-5 w-48 bg-zinc-800" />
+          <Skeleton className="h-4 w-72 bg-zinc-800" />
+        </div>
+        <Skeleton className="h-[300px] md:h-[400px] lg:h-[500px] rounded-xl bg-zinc-900" />
+      </div>
+    ),
+  }
+);
+
+export function ImpactMapSection() {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold text-white">Impact Projects</h2>
+        <p className="text-sm text-zinc-400">
+          Explore impact projects around the world. Toggle between street and
+          satellite views.
+        </p>
+      </div>
+      <ImpactMap />
+    </div>
+  );
+}

--- a/apps/web/src/components/molecules/MapLayerToggle.test.tsx
+++ b/apps/web/src/components/molecules/MapLayerToggle.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MapLayerToggle } from "./MapLayerToggle";
+
+describe("MapLayerToggle", () => {
+  it("renders both layer buttons", () => {
+    render(
+      <MapLayerToggle layer="vector" onLayerChange={() => {}} />
+    );
+
+    expect(screen.getByRole("radio", { name: /street view/i })).toBeDefined();
+    expect(
+      screen.getByRole("radio", { name: /satellite view/i })
+    ).toBeDefined();
+  });
+
+  it("highlights the active layer", () => {
+    render(
+      <MapLayerToggle layer="satellite" onLayerChange={() => {}} />
+    );
+
+    const satellite = screen.getByRole("radio", { name: /satellite view/i });
+    const street = screen.getByRole("radio", { name: /street view/i });
+
+    expect(satellite.getAttribute("aria-checked")).toBe("true");
+    expect(street.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("calls onLayerChange when clicking a layer button", () => {
+    const onLayerChange = vi.fn();
+    render(
+      <MapLayerToggle layer="vector" onLayerChange={onLayerChange} />
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /satellite view/i }));
+
+    expect(onLayerChange).toHaveBeenCalledWith("satellite");
+  });
+
+  it("disables buttons when disabled prop is true", () => {
+    render(
+      <MapLayerToggle
+        layer="vector"
+        onLayerChange={() => {}}
+        disabled={true}
+      />
+    );
+
+    const buttons = screen.getAllByRole("radio");
+    buttons.forEach((button) => {
+      expect(button.hasAttribute("disabled")).toBe(true);
+    });
+  });
+
+  it("disables buttons while switching layers", () => {
+    render(
+      <MapLayerToggle
+        layer="vector"
+        onLayerChange={() => {}}
+        isSwitching={true}
+      />
+    );
+
+    const buttons = screen.getAllByRole("radio");
+    buttons.forEach((button) => {
+      expect(button.hasAttribute("disabled")).toBe(true);
+    });
+  });
+
+  it("shows spinner when isSwitching is true", () => {
+    render(
+      <MapLayerToggle
+        layer="vector"
+        onLayerChange={() => {}}
+        isSwitching={true}
+      />
+    );
+
+    expect(screen.getByRole("status", { name: /switching layer/i })).toBeDefined();
+  });
+
+  it("does not show spinner when isSwitching is false", () => {
+    render(
+      <MapLayerToggle
+        layer="vector"
+        onLayerChange={() => {}}
+        isSwitching={false}
+      />
+    );
+
+    expect(
+      screen.queryByRole("status", { name: /switching layer/i })
+    ).toBeNull();
+  });
+
+  it("has correct radiogroup aria role", () => {
+    render(
+      <MapLayerToggle layer="vector" onLayerChange={() => {}} />
+    );
+
+    const group = screen.getByRole("radiogroup");
+    expect(group).toBeDefined();
+    expect(group.getAttribute("aria-label")).toBe("Map layer");
+  });
+
+  it("supports keyboard navigation", () => {
+    const onLayerChange = vi.fn();
+    render(
+      <MapLayerToggle layer="vector" onLayerChange={onLayerChange} />
+    );
+
+    const satellite = screen.getByRole("radio", { name: /satellite view/i });
+    satellite.focus();
+    fireEvent.click(satellite);
+
+    expect(onLayerChange).toHaveBeenCalledWith("satellite");
+  });
+
+  it("renders icons with aria-hidden", () => {
+    render(
+      <MapLayerToggle layer="vector" onLayerChange={() => {}} />
+    );
+
+    const icons = document.querySelectorAll("[aria-hidden='true']");
+    expect(icons.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/components/molecules/MapLayerToggle.tsx
+++ b/apps/web/src/components/molecules/MapLayerToggle.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Satellite, Map } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { MapLayer } from "@/hooks/use-map-layer";
+
+export interface MapLayerToggleProps {
+  layer: MapLayer;
+  onLayerChange: (layer: MapLayer) => void;
+  disabled?: boolean;
+  isSwitching?: boolean;
+}
+
+const layers: { id: MapLayer; label: string; icon: typeof Map }[] = [
+  { id: "vector", label: "Street", icon: Map },
+  { id: "satellite", label: "Satellite", icon: Satellite },
+];
+
+export function MapLayerToggle({
+  layer,
+  onLayerChange,
+  disabled = false,
+  isSwitching = false,
+}: MapLayerToggleProps) {
+  return (
+    <div
+      className="flex items-center gap-1 rounded-lg border border-zinc-700 bg-zinc-900/80 p-1 backdrop-blur-sm"
+      role="radiogroup"
+      aria-label="Map layer"
+    >
+      {layers.map(({ id, label, icon: Icon }) => (
+        <button
+          key={id}
+          type="button"
+          role="radio"
+          aria-checked={layer === id}
+          aria-label={`${label} view`}
+          disabled={disabled || isSwitching}
+          onClick={() => onLayerChange(id)}
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-all",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fundable-purple-2 focus-visible:ring-offset-1 focus-visible:ring-offset-zinc-900",
+            "disabled:cursor-not-allowed disabled:opacity-50",
+            layer === id
+              ? "bg-fundable-purple-2 text-white shadow-sm"
+              : "text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800"
+          )}
+        >
+          <Icon className="size-3.5 shrink-0" aria-hidden="true" />
+          <span className="hidden sm:inline">{label}</span>
+        </button>
+      ))}
+      {isSwitching && (
+        <div
+          className="ml-1 size-3.5 animate-spin rounded-full border-2 border-zinc-500 border-t-transparent"
+          role="status"
+          aria-label="Switching layer"
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/organisms/ImpactMap.test.tsx
+++ b/apps/web/src/components/organisms/ImpactMap.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { ImpactMap } from "./ImpactMap";
+
+// ---------------------------------------------------------------------------
+// Mock maplibre-gl – jsdom has no WebGL so we supply a fake Map
+// ---------------------------------------------------------------------------
+const { MockMap, mockOn, mockRemove, mockAddSource, mockAddLayer } = vi.hoisted(() => {
+  const mockOn = vi.fn();
+  const mockRemove = vi.fn();
+  const mockAddSource = vi.fn();
+  const mockAddLayer = vi.fn();
+
+  const MockMap = vi.fn().mockImplementation(() => ({
+    on: mockOn,
+    remove: mockRemove,
+    addSource: mockAddSource,
+    addLayer: mockAddLayer,
+    getSource: vi.fn().mockReturnValue(null),
+    getLayer: vi.fn().mockReturnValue(null),
+    removeSource: vi.fn(),
+    removeLayer: vi.fn(),
+  }));
+
+  return { MockMap, mockOn, mockRemove, mockAddSource, mockAddLayer };
+});
+
+vi.mock("maplibre-gl", () => ({
+  default: {
+    Map: MockMap,
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fireMapLoad() {
+  const call = mockOn.mock.calls.find(([e]: [string]) => e === "load");
+  if (call) call[1]();
+}
+
+function fireMapError() {
+  const call = mockOn.mock.calls.find(([e]: [string]) => e === "error");
+  if (call) call[1]({ error: { status: 404, message: "Tile not found" } });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ImpactMap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders the map container", () => {
+    render(<ImpactMap />);
+    expect(screen.getByLabelText("Impact projects map")).toBeDefined();
+  });
+
+  it("renders the layer toggle", () => {
+    render(<ImpactMap />);
+    expect(screen.getByRole("radiogroup", { name: /map layer/i })).toBeDefined();
+  });
+
+  it("shows loading skeleton before map loads", () => {
+    render(<ImpactMap />);
+    expect(document.querySelectorAll("[data-slot='skeleton']").length).toBeGreaterThan(0);
+  });
+
+  it("hides skeleton after map loads", async () => {
+    render(<ImpactMap />);
+
+    await act(async () => {
+      fireMapLoad();
+    });
+
+    await waitFor(() => {
+      expect(document.querySelectorAll("[data-slot='skeleton']").length).toBe(0);
+    });
+  });
+
+  it("shows loading overlay when switching layers", async () => {
+    render(<ImpactMap />);
+
+    await act(async () => {
+      fireMapLoad();
+    });
+
+    const satelliteBtn = screen.getByRole("radio", { name: /satellite view/i });
+    await act(async () => {
+      fireEvent.click(satelliteBtn);
+    });
+
+    expect(screen.getByRole("status", { name: /switching map layer/i })).toBeDefined();
+  });
+
+  it("handles tile loading errors gracefully", async () => {
+    render(<ImpactMap />);
+
+    await act(async () => {
+      fireMapLoad();
+    });
+
+    await act(async () => {
+      fireMapError();
+    });
+
+    expect(screen.getByRole("alert")).toBeDefined();
+    expect(screen.getByText(/failed to load map tiles/i)).toBeDefined();
+  });
+
+  it("disables toggle before map loads", () => {
+    render(<ImpactMap />);
+
+    const buttons = screen.getAllByRole("radio");
+    buttons.forEach((button) => {
+      expect(button.hasAttribute("disabled")).toBe(true);
+    });
+  });
+
+  it("enables toggle after map loads", async () => {
+    render(<ImpactMap />);
+
+    await act(async () => {
+      fireMapLoad();
+    });
+
+    await waitFor(() => {
+      const buttons = screen.getAllByRole("radio");
+      buttons.forEach((button) => {
+        expect(button.hasAttribute("disabled")).toBe(false);
+      });
+    });
+  });
+
+  it("allows retrying after tile error", async () => {
+    render(<ImpactMap />);
+
+    await act(async () => {
+      fireMapLoad();
+    });
+
+    await act(async () => {
+      fireMapError();
+    });
+
+    const retryBtn = screen.getByRole("button", { name: /retry/i });
+    await act(async () => {
+      fireEvent.click(retryBtn);
+    });
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("switches map source when layer changes", async () => {
+    render(<ImpactMap />);
+
+    await act(async () => {
+      fireMapLoad();
+    });
+
+    const satelliteBtn = screen.getByRole("radio", { name: /satellite view/i });
+    await act(async () => {
+      fireEvent.click(satelliteBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockAddSource).toHaveBeenCalled();
+      expect(mockAddLayer).toHaveBeenCalled();
+    });
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(<ImpactMap className="custom-class" />);
+    const section = container.querySelector("section");
+    expect(section?.classList.contains("custom-class")).toBe(true);
+  });
+
+  it("cleans up map on unmount", () => {
+    const { unmount } = render(<ImpactMap />);
+    unmount();
+    expect(mockRemove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/organisms/ImpactMap.tsx
+++ b/apps/web/src/components/organisms/ImpactMap.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useRef, useEffect, useState, useCallback } from "react";
+import maplibregl from "maplibre-gl";
+import "maplibre-gl/dist/maplibre-gl.css";
+import { cn } from "@/lib/utils";
+import { MapLayerToggle } from "@/components/molecules/MapLayerToggle";
+import { useMapLayer, type MapLayer } from "@/hooks/use-map-layer";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const TILE_SOURCES: Record<MapLayer, { tiles: string[]; attribution: string }> =
+  {
+    vector: {
+      tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+      attribution: "&copy; OpenStreetMap contributors",
+    },
+    satellite: {
+      tiles: [
+        "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+      ],
+      attribution:
+        "&copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community",
+    },
+  };
+
+const DEFAULT_CENTER: [number, number] = [0, 20];
+const DEFAULT_ZOOM = 1.5;
+
+interface ErrorState {
+  message: string;
+  retry: () => void;
+}
+
+export interface ImpactMapProps {
+  className?: string;
+}
+
+export function ImpactMap({ className }: ImpactMapProps) {
+  const mapContainerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
+  const [mapLoaded, setMapLoaded] = useState(false);
+  const [tileError, setTileError] = useState<ErrorState | null>(null);
+
+  const { layer, setLayer, isSwitching, error, clearError } = useMapLayer();
+
+  const updateLayer = useCallback(
+    (map: maplibregl.Map, newLayer: MapLayer) => {
+      const sourceId = "basemap";
+      const layerId = "basemap-layer";
+
+      if (map.getLayer(layerId)) map.removeLayer(layerId);
+      if (map.getSource(sourceId)) map.removeSource(sourceId);
+
+      const source = TILE_SOURCES[newLayer];
+
+      map.addSource(sourceId, {
+        type: "raster",
+        tiles: source.tiles,
+        tileSize: 256,
+        attribution: source.attribution,
+      });
+
+      map.addLayer({ id: layerId, type: "raster", source: sourceId });
+
+      setTileError(null);
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!mapContainerRef.current || mapRef.current) return;
+
+    const map = new maplibregl.Map({
+      container: mapContainerRef.current,
+      zoom: DEFAULT_ZOOM,
+      center: DEFAULT_CENTER,
+      attributionControl: true,
+    });
+
+    map.on("load", () => {
+      updateLayer(map, layer);
+      setMapLoaded(true);
+    });
+
+    map.on("error", (e) => {
+      if (
+        e.error &&
+        typeof e.error === "object" &&
+        "status" in e.error &&
+        (e.error as { status: number }).status === 404
+      ) {
+        setTileError({
+          message: "Failed to load map tiles. Please try again.",
+          retry: () => {
+            setTileError(null);
+            if (mapRef.current) {
+              updateLayer(mapRef.current, layer);
+            }
+          },
+        });
+      }
+    });
+
+    mapRef.current = map;
+
+    return () => {
+      map.remove();
+      mapRef.current = null;
+    };
+  }, [updateLayer, layer]);
+
+  useEffect(() => {
+    if (!mapRef.current || !mapLoaded) return;
+    updateLayer(mapRef.current, layer);
+  }, [layer, mapLoaded, updateLayer]);
+
+  return (
+    <section
+      className={cn("relative flex flex-col overflow-hidden rounded-xl", className)}
+      aria-label="Impact projects map"
+    >
+      <div className="relative flex-1 min-h-[300px] md:min-h-[400px] lg:min-h-[500px]">
+        {!mapLoaded && (
+          <Skeleton className="absolute inset-0 z-10 rounded-xl bg-zinc-900" />
+        )}
+
+        <div
+          ref={mapContainerRef}
+          className={cn(
+            "absolute inset-0 rounded-xl",
+            !mapLoaded && "invisible"
+          )}
+        />
+
+        {isSwitching && (
+          <div
+            className="absolute inset-0 z-20 flex items-center justify-center bg-black/40 rounded-xl"
+            role="status"
+            aria-label="Switching map layer"
+          >
+            <div className="size-8 animate-spin rounded-full border-4 border-fundable-purple-2 border-t-transparent" />
+          </div>
+        )}
+
+        {tileError && (
+          <div
+            className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-3 bg-zinc-900/90 rounded-xl p-6"
+            role="alert"
+          >
+            <p className="text-sm text-zinc-400 text-center">{tileError.message}</p>
+            <button
+              type="button"
+              onClick={tileError.retry}
+              className="rounded-md bg-fundable-purple-2 px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-fundable-purple-2/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fundable-purple-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {error && (
+          <div
+            className="absolute top-4 left-1/2 -translate-x-1/2 z-30 flex items-center gap-2 rounded-lg bg-red-900/80 px-4 py-2 text-xs text-red-200 backdrop-blur-sm"
+            role="alert"
+          >
+            <span>{error.message}</span>
+            <button
+              type="button"
+              onClick={clearError}
+              className="ml-1 text-red-300 underline hover:text-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 rounded"
+              aria-label="Dismiss error"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className="absolute top-3 right-3 z-20">
+        <MapLayerToggle
+          layer={layer}
+          onLayerChange={setLayer}
+          disabled={!mapLoaded}
+          isSwitching={isSwitching}
+        />
+      </div>
+
+      {!mapLoaded && (
+        <div className="flex items-center justify-center gap-2 p-4 text-xs text-zinc-500">
+          <div className="size-3 animate-spin rounded-full border-2 border-zinc-600 border-t-transparent" />
+          Loading map...
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/hooks/use-map-layer.test.ts
+++ b/apps/web/src/hooks/use-map-layer.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useMapLayer } from "./use-map-layer";
+
+describe("useMapLayer", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("initialises with vector layer", () => {
+    const { result } = renderHook(() => useMapLayer());
+    expect(result.current.layer).toBe("vector");
+  });
+
+  it("reads persisted layer from sessionStorage", () => {
+    sessionStorage.setItem("fundable-map-layer", "satellite");
+    const { result } = renderHook(() => useMapLayer());
+    expect(result.current.layer).toBe("satellite");
+  });
+
+  it("falls back to vector for invalid stored values", () => {
+    sessionStorage.setItem("fundable-map-layer", "invalid");
+    const { result } = renderHook(() => useMapLayer());
+    expect(result.current.layer).toBe("vector");
+  });
+
+  it("switches to satellite layer", () => {
+    const { result } = renderHook(() => useMapLayer());
+
+    act(() => {
+      result.current.setLayer("satellite");
+    });
+
+    expect(result.current.layer).toBe("satellite");
+  });
+
+  it("toggles between vector and satellite", () => {
+    const { result } = renderHook(() => useMapLayer());
+
+    act(() => {
+      result.current.toggleLayer();
+    });
+
+    expect(result.current.layer).toBe("satellite");
+
+    act(() => {
+      result.current.toggleLayer();
+    });
+
+    expect(result.current.layer).toBe("vector");
+  });
+
+  it("persists layer to sessionStorage", () => {
+    const { result } = renderHook(() => useMapLayer());
+
+    act(() => {
+      result.current.setLayer("satellite");
+    });
+
+    expect(sessionStorage.getItem("fundable-map-layer")).toBe("satellite");
+  });
+
+  it("sets isSwitching to true on layer change", () => {
+    const { result } = renderHook(() => useMapLayer());
+
+    act(() => {
+      result.current.setLayer("satellite");
+    });
+
+    expect(result.current.isSwitching).toBe(true);
+  });
+
+  it("clears isSwitching after timeout", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useMapLayer());
+
+    act(() => {
+      result.current.setLayer("satellite");
+    });
+
+    expect(result.current.isSwitching).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current.isSwitching).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it("clears error when setLayer is called", () => {
+    const { result } = renderHook(() => useMapLayer());
+
+    act(() => {
+      result.current.setLayer("satellite");
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+
+  it("provides clearError function that clears the error", () => {
+    const { result } = renderHook(() => useMapLayer());
+
+    act(() => {
+      result.current.setLayer("satellite");
+    });
+
+    act(() => {
+      result.current.clearError();
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+
+  it("handles sessionStorage write failure gracefully", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("Storage full");
+    });
+
+    const { result } = renderHook(() => useMapLayer());
+
+    act(() => {
+      result.current.setLayer("satellite");
+    });
+
+    expect(result.current.layer).toBe("satellite");
+  });
+
+  it("handles sessionStorage read failure gracefully", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("Storage error");
+    });
+
+    const { result } = renderHook(() => useMapLayer());
+    expect(result.current.layer).toBe("vector");
+  });
+});

--- a/apps/web/src/hooks/use-map-layer.ts
+++ b/apps/web/src/hooks/use-map-layer.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState, useCallback, useEffect, useRef } from "react";
+
+export type MapLayer = "vector" | "satellite";
+
+const STORAGE_KEY = "fundable-map-layer";
+
+function getInitialLayer(): MapLayer {
+  if (typeof window === "undefined") return "vector";
+  try {
+    const stored = sessionStorage.getItem(STORAGE_KEY);
+    if (stored === "vector" || stored === "satellite") return stored;
+  } catch {}
+  return "vector";
+}
+
+export interface UseMapLayerReturn {
+  layer: MapLayer;
+  setLayer: (layer: MapLayer) => void;
+  toggleLayer: () => void;
+  isSwitching: boolean;
+  error: Error | null;
+  clearError: () => void;
+}
+
+export function useMapLayer(): UseMapLayerReturn {
+  const [layer, setLayerState] = useState<MapLayer>(getInitialLayer);
+  const [isSwitching, setIsSwitching] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const switchingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(STORAGE_KEY, layer);
+    } catch {}
+  }, [layer]);
+
+  const setLayer = useCallback((newLayer: MapLayer) => {
+    setError(null);
+    setIsSwitching(true);
+    setLayerState(newLayer);
+
+    if (switchingTimeoutRef.current) {
+      clearTimeout(switchingTimeoutRef.current);
+    }
+
+    switchingTimeoutRef.current = setTimeout(() => {
+      setIsSwitching(false);
+    }, 500);
+  }, []);
+
+  const toggleLayer = useCallback(() => {
+    setLayer(layer === "vector" ? "satellite" : "vector");
+  }, [layer, setLayer]);
+
+  const clearError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (switchingTimeoutRef.current) {
+        clearTimeout(switchingTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    layer,
+    setLayer,
+    toggleLayer,
+    isSwitching,
+    error,
+    clearError,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.3)
+      maplibre-gl:
+        specifier: ^6.0.0
+        version: 6.0.0
       next:
         specifier: 16.1.2
         version: 16.1.2(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1013,6 +1016,35 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@mapbox/jsonlint-lines-primitives@2.0.3':
+    resolution: {integrity: sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==}
+    engines: {node: '>= 22'}
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.2.0':
+    resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
+
+  '@mapbox/unitbezier@1.0.0':
+    resolution: {integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==}
+
+  '@mapbox/vector-tile@3.0.0':
+    resolution: {integrity: sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==}
+
+  '@maplibre/geojson-vt@6.1.1':
+    resolution: {integrity: sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==}
+
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
+    resolution: {integrity: sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==}
+    hasBin: true
+
+  '@maplibre/mlt@1.1.12':
+    resolution: {integrity: sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==}
+
+  '@maplibre/vt-pbf@4.3.2':
+    resolution: {integrity: sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==}
 
   '@mobily/ts-belt@3.13.1':
     resolution: {integrity: sha512-K5KqIhPI/EoCTbA6CGbrenM9s41OouyK8A03fGJJcla/zKucsgLbz8HNbeseoLarRPgyWJsUyCYqFhI7t3Ra9Q==}
@@ -2170,10 +2202,12 @@ packages:
   '@stellar/stellar-base@13.1.0':
     resolution: {integrity: sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==}
     engines: {node: '>=18.0.0'}
+    deprecated: This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.
 
   '@stellar/stellar-base@14.1.0':
     resolution: {integrity: sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==}
     engines: {node: '>=20.0.0'}
+    deprecated: This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.
 
   '@stellar/stellar-sdk@13.3.0':
     resolution: {integrity: sha512-8+GHcZLp+mdin8gSjcgfb/Lb6sSMYRX6Nf/0LcSJxvjLQR0XHpjGzOiRbYb2jSXo51EnA6kAV5j+4Pzh5OUKUg==}
@@ -2502,6 +2536,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -2665,6 +2702,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -3501,6 +3539,9 @@ packages:
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
+  earcut@3.2.3:
+    resolution: {integrity: sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -3941,6 +3982,9 @@ packages:
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -4331,6 +4375,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
@@ -4359,6 +4406,9 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  kdbush@4.1.0:
+    resolution: {integrity: sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4519,6 +4569,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  maplibre-gl@6.0.0:
+    resolution: {integrity: sha512-1wBgEhzTZfA+cDpFdt0fM1mJA5mJ90fifORJ7D8JcKLJCvPT/iTx9bNxkP7DqEYde65DJd7gE7h83khwNRqdyg==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -4583,6 +4637,9 @@ packages:
 
   multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
   mustache@4.0.0:
     resolution: {integrity: sha512-FJgjyX/IVkbXBXYUwH+OYwQKqWpFPLaLVESd70yHjSDunwzV2hZOoTBvPf4KLoxesUzzyfTH6F784Uqd7Wm5yA==}
@@ -4800,6 +4857,10 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pbf@5.1.2:
+    resolution: {integrity: sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==}
+    hasBin: true
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -4851,6 +4912,9 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -4882,6 +4946,9 @@ packages:
     resolution: {integrity: sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==}
     engines: {node: '>=12.0.0'}
 
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
+
   proxy-compare@2.5.1:
     resolution: {integrity: sha512-oyfc0Tx87Cpwva5ZXezSp5V9vht1c7dZBhvuV/y3ctkgMVUmiAGDVeeB0dKhGSyT0v1ZTEQYpe/RXlBVBNuCLA==}
 
@@ -4912,6 +4979,9 @@ packages:
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
@@ -5060,6 +5130,9 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
 
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
@@ -5422,6 +5495,9 @@ packages:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
+
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
@@ -5707,6 +5783,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valtio@1.11.2:
@@ -6866,6 +6943,43 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@mapbox/jsonlint-lines-primitives@2.0.3': {}
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.2.0': {}
+
+  '@mapbox/unitbezier@1.0.0': {}
+
+  '@mapbox/vector-tile@3.0.0':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 5.1.2
+
+  '@maplibre/geojson-vt@6.1.1':
+    dependencies:
+      kdbush: 4.1.0
+
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
+      '@mapbox/unitbezier': 1.0.0
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
+  '@maplibre/mlt@1.1.12':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
+  '@maplibre/vt-pbf@4.3.2':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 5.1.2
 
   '@mobily/ts-belt@3.13.1': {}
 
@@ -8623,6 +8737,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -9860,6 +9976,8 @@ snapshots:
       readable-stream: 3.6.2
       stream-shift: 1.0.3
 
+  earcut@3.2.3: {}
+
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -10521,6 +10639,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  gl-matrix@3.4.4: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -10949,6 +11069,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-pretty-compact@4.0.0: {}
+
   json-stringify-safe@5.0.1: {}
 
   json5@1.0.2:
@@ -10980,6 +11102,8 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
+
+  kdbush@4.1.0: {}
 
   keyv@4.5.4:
     dependencies:
@@ -11119,6 +11243,26 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  maplibre-gl@6.0.0:
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.2.0
+      '@mapbox/unitbezier': 1.0.0
+      '@mapbox/vector-tile': 3.0.0
+      '@maplibre/geojson-vt': 6.1.1
+      '@maplibre/maplibre-gl-style-spec': 26.2.1
+      '@maplibre/mlt': 1.1.12
+      '@maplibre/vt-pbf': 4.3.2
+      '@types/geojson': 7946.0.16
+      earcut: 3.2.3
+      gl-matrix: 3.4.4
+      kdbush: 4.1.0
+      murmurhash-js: 1.0.0
+      pbf: 5.1.2
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
   math-intrinsics@1.1.0: {}
 
   md5.js@1.3.5:
@@ -11180,6 +11324,8 @@ snapshots:
   ms@2.1.3: {}
 
   multiformats@9.9.0: {}
+
+  murmurhash-js@1.0.0: {}
 
   mustache@4.0.0: {}
 
@@ -11396,6 +11542,10 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pbf@5.1.2:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -11449,6 +11599,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  potpack@2.1.0: {}
+
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
@@ -11486,6 +11638,8 @@ snapshots:
       '@types/node': 20.19.37
       long: 5.2.5
 
+  protocol-buffers-schema@3.6.1: {}
+
   proxy-compare@2.5.1: {}
 
   proxy-from-env@1.1.0: {}
@@ -11515,6 +11669,8 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  quickselect@3.0.0: {}
 
   radix3@1.1.2: {}
 
@@ -11673,6 +11829,10 @@ snapshots:
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.1
 
   resolve@1.22.11:
     dependencies:
@@ -12134,6 +12294,8 @@ snapshots:
       picomatch: 4.0.3
 
   tinypool@1.1.1: {}
+
+  tinyqueue@3.0.0: {}
 
   tinyrainbow@1.2.0: {}
 


### PR DESCRIPTION
Add map infrastructure for Impact Projects with satellite/vector layer switching.

- Install maplibre-gl as the mapping library
- Add useMapLayer hook with sessionStorage persistence
- Add MapLayerToggle molecule component with ARIA support
- Add ImpactMap organism component with tile error handling
- Add ImpactMapSection module to dashboard page
- Add comprehensive unit tests (34 tests) covering render, switch, loading, error, disabled, accessibility, and keyboard states
- Follow atomic design, Tailwind v4, and Fundable theme

Closes #527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an interactive “Impact Projects” map to the dashboard.
  - Added Street View and Satellite View layer switching.
  - Map loading, switching, retry, and error states are now clearly indicated.
  - Selected map layers persist between sessions.

- **Accessibility**
  - Added keyboard-accessible map layer controls with appropriate status messaging.

- **Tests**
  - Added coverage for map rendering, layer switching, loading states, errors, persistence, and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->