### PR TITLE
Fix ensureSafeNumber throwing on large Soroban Stream IDs

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -47,11 +47,8 @@ function mapServiceStream(stream: ServiceStream): Stream {
     };
 }
 
-function ensureSafeNumber(value: bigint): number {
-    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
-        throw new Error('Returned stream id exceeds JavaScript safe integer range');
-    }
-    return Number(value);
+function serializeStreamId(value: bigint): string {
+    return value.toString();
 }
 
 async function signAndSendTx<T>(
@@ -109,7 +106,7 @@ export async function createStream(params: {
     startTime: number;
     endTime: number;
     signTransaction?: WalletSigner;
-}): Promise<number> {
+}): Promise<string> {
     const client = createPaymentStreamClient(params.sender);
     const tx = await client.createStream({
         sender: params.sender,
@@ -127,7 +124,7 @@ export async function createStream(params: {
     if (typeof streamId !== 'bigint') {
         throw new Error('Contract did not return a stream id');
     }
-    return ensureSafeNumber(streamId);
+    return serializeStreamId(streamId);
 }
 
 export async function withdraw(params: {


### PR DESCRIPTION
Closes #372

---

createStream() threw an unhandled error whenever a Soroban stream ID exceeded Number.MAX_SAFE_INTEGER (2^53 - 1). Replaced ensureSafeNumber with serializeStreamId, which serializes the bigint to a string instead of forcing a lossy/unsafe number cast. createStream() now returns Promise<string>.

Confirmed via tsc --noEmit with no downstream type errors. issue #372 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream creation reliability by preserving stream IDs as exact text values.
  * Prevented failures when stream IDs exceed JavaScript’s safe numeric range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->