### PR TITLE
fix(web): fetch dynamic offramp minimum limits

### DIFF
--- a/apps/web/src/app/(overview)/offramp/page.tsx
+++ b/apps/web/src/app/(overview)/offramp/page.tsx
@@ -37,6 +37,8 @@ export default function OfframpPage() {
         goBack,
         currentTokenBalance,
         isLoadingBalance,
+        providerMinimumAmount,
+        isLoadingProviderMinimum,
     } = useOfframpBridge();
 
     const [showQuoteModal, setShowQuoteModal] = useState(false);
@@ -134,6 +136,8 @@ export default function OfframpPage() {
                                                 onChange={handleFormChange}
                                                 maxBalance={isLoadingBalance ? "Loading..." : currentTokenBalance}
                                                 onMaxClick={handleMaxClick}
+                                                minimumAmount={providerMinimumAmount}
+                                                isLoadingMinimum={isLoadingProviderMinimum}
                                             />
                                         </div>
 

--- a/apps/web/src/components/offramp/OfframpForm.test.tsx
+++ b/apps/web/src/components/offramp/OfframpForm.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OfframpForm } from "./OfframpForm";
+
+const formState = {
+    token: "USDC" as const,
+    amount: "",
+    country: "NG" as const,
+    bankCode: "",
+    accountNumber: "",
+    accountName: "",
+};
+
+describe("OfframpForm", () => {
+    it("shows the minimum supplied by the provider limits service", () => {
+        render(
+            <OfframpForm
+                formState={formState}
+                onChange={vi.fn()}
+                minimumAmount={25}
+            />
+        );
+
+        expect(screen.getByText(/Minimum: 25 USDC/)).toBeTruthy();
+    });
+
+    it("shows a loading state while provider limits are being fetched", () => {
+        render(
+            <OfframpForm
+                formState={formState}
+                onChange={vi.fn()}
+                minimumAmount={1}
+                isLoadingMinimum
+            />
+        );
+
+        expect(screen.getByText(/Loading provider minimum/)).toBeTruthy();
+    });
+});

--- a/apps/web/src/components/offramp/OfframpForm.tsx
+++ b/apps/web/src/components/offramp/OfframpForm.tsx
@@ -20,9 +20,18 @@ interface OfframpFormProps {
     onChange: (field: keyof OfframpFormState, value: string) => void;
     maxBalance?: string;
     onMaxClick?: () => void;
+    minimumAmount: number;
+    isLoadingMinimum?: boolean;
 }
 
-export function OfframpForm({ formState, onChange, maxBalance, onMaxClick }: OfframpFormProps) {
+export function OfframpForm({
+    formState,
+    onChange,
+    maxBalance,
+    onMaxClick,
+    minimumAmount,
+    isLoadingMinimum = false,
+}: OfframpFormProps) {
     const [isKycNoticeVisible, setIsKycNoticeVisible] = useState(true);
 
     return (
@@ -86,10 +95,9 @@ export function OfframpForm({ formState, onChange, maxBalance, onMaxClick }: Off
                 <div className="space-y-2">
                     <Label htmlFor="amount" className="text-fundable-light-grey text-sm">
                         Amount
-                        {(() => {
-                            const selectedToken = SUPPORTED_OFFRAMP_TOKENS.find(t => t.symbol === formState.token);
-                            return selectedToken ? ` (Minimum: ${selectedToken.minimumAmount} ${selectedToken.symbol})` : '';
-                        })()}
+                        {isLoadingMinimum
+                            ? " (Loading provider minimum...)"
+                            : ` (Minimum: ${minimumAmount} ${formState.token})`}
                     </Label>
                     <div className="relative">
                         <Input

--- a/apps/web/src/hooks/useOfframpBridge.rate-limit.test.ts
+++ b/apps/web/src/hooks/useOfframpBridge.rate-limit.test.ts
@@ -24,6 +24,8 @@ vi.mock("@/services/offramp.service", () => ({
         getAggregatedRates: vi.fn(),
         createOfframp: vi.fn(),
         getQuoteStatus: vi.fn(),
+        getUserLimits: vi.fn(),
+        getProviderLimits: vi.fn(),
     },
 }));
 
@@ -54,6 +56,19 @@ describe("useOfframpBridge rate limit handling", () => {
         vi.mocked(offrampService.getBankList).mockResolvedValue({
             success: true,
             data: [],
+        });
+        vi.mocked(offrampService.getUserLimits).mockResolvedValue({
+            success: true,
+            data: {
+                dailyLimit: 1000,
+                dailyUsed: 0,
+                remainingDaily: 1000,
+                tier: "standard",
+            },
+        });
+        vi.mocked(offrampService.getProviderLimits).mockResolvedValue({
+            success: true,
+            data: { minimumAmount: 10, providers: [] },
         });
     });
 

--- a/apps/web/src/hooks/useOfframpBridge.test.ts
+++ b/apps/web/src/hooks/useOfframpBridge.test.ts
@@ -19,6 +19,7 @@ vi.mock("@/services/offramp.service", () => ({
         updateQuoteTxHash: vi.fn(),
         getQuoteStatus: vi.fn(),
         getUserLimits: vi.fn(),
+        getProviderLimits: vi.fn(),
     },
 }));
 
@@ -108,6 +109,16 @@ describe("useOfframpBridge", () => {
                 dailyUsed: 0,
                 remainingDaily: 1000,
                 tier: "standard",
+            },
+        });
+        (offrampService.getProviderLimits as ReturnType<typeof vi.fn>).mockResolvedValue({
+            success: true,
+            data: {
+                minimumAmount: 10,
+                providers: [
+                    { providerId: "cashwyre", minimumAmount: 10 },
+                    { providerId: "autoramp", minimumAmount: 10 },
+                ],
             },
         });
     });
@@ -210,6 +221,32 @@ describe("useOfframpBridge", () => {
         await drainTimers();
 
         expect(result.current.quoteError).toBe("Failed to fetch rates");
+    });
+
+    it("rejects an amount below the provider minimum", async () => {
+        const { result } = renderHook(() => useOfframpBridge(), { wrapper: createWrapper() });
+
+        act(() => { result.current.handleFormChange("amount", "5"); });
+        await drainTimers();
+
+        expect(result.current.providerMinimumAmount).toBe(10);
+        await act(async () => { await result.current.getQuote({ ...result.current.formState }); });
+
+        expect(result.current.error).toBe("Amount must be at least 10 USDC");
+        expect(offrampService.createOfframp).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the token minimum when provider limits are unavailable", async () => {
+        (offrampService.getProviderLimits as ReturnType<typeof vi.fn>).mockResolvedValue({
+            success: false,
+            error: "Provider limits unavailable",
+        });
+        const { result } = renderHook(() => useOfframpBridge(), { wrapper: createWrapper() });
+
+        await drainTimers();
+
+        expect(result.current.providerMinimumAmount).toBe(1);
+        expect(result.current.isLoadingProviderMinimum).toBe(false);
     });
 
     // --- getQuote (form → quote step) ---

--- a/apps/web/src/hooks/useOfframpBridge.ts
+++ b/apps/web/src/hooks/useOfframpBridge.ts
@@ -81,6 +81,10 @@ interface UseOfframpBridgeReturn {
     userLimits: UserOfframpLimits | null;
     isLoadingLimits: boolean;
 
+    // Provider minimum
+    providerMinimumAmount: number;
+    isLoadingProviderMinimum: boolean;
+
     // Controls
     reset: () => void;
     goBack: () => void;
@@ -120,6 +124,10 @@ export function useOfframpBridge(): UseOfframpBridgeReturn {
     // User Limits State
     const [userLimits, setUserLimits] = useState<UserOfframpLimits | null>(null);
     const [isLoadingLimits, setIsLoadingLimits] = useState(false);
+    const [providerMinimumAmount, setProviderMinimumAmount] = useState(
+        SUPPORTED_OFFRAMP_TOKENS.find((token) => token.symbol === "USDC")?.minimumAmount ?? 0
+    );
+    const [isLoadingProviderMinimum, setIsLoadingProviderMinimum] = useState(false);
 
     // Polling refs
     const payoutPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -166,6 +174,46 @@ export function useOfframpBridge(): UseOfframpBridgeReturn {
         fetchLimits();
         return () => controller.abort();
     }, [isConnected, address]);
+
+    // ---------- Effects: Provider Minimum ----------
+
+    useEffect(() => {
+        const fallbackMinimum =
+            SUPPORTED_OFFRAMP_TOKENS.find((token) => token.symbol === formState.token)
+                ?.minimumAmount ?? 0;
+        const controller = new AbortController();
+
+        setProviderMinimumAmount(fallbackMinimum);
+        setIsLoadingProviderMinimum(true);
+
+        const fetchProviderMinimum = async () => {
+            try {
+                const result = await offrampService.getProviderLimits(
+                    {
+                        token: formState.token,
+                        country: formState.country,
+                        network: "polygon",
+                    },
+                    controller.signal
+                );
+
+                if (controller.signal.aborted) return;
+                if (result.success && result.data) {
+                    setProviderMinimumAmount(result.data.minimumAmount);
+                } else {
+                    console.warn("Failed to fetch provider offramp limits:", result.error);
+                }
+            } catch (error) {
+                if (controller.signal.aborted) return;
+                console.warn("Error fetching provider offramp limits:", error);
+            } finally {
+                if (!controller.signal.aborted) setIsLoadingProviderMinimum(false);
+            }
+        };
+
+        fetchProviderMinimum();
+        return () => controller.abort();
+    }, [formState.token, formState.country]);
 
     // ---------- Handlers ----------
 
@@ -332,11 +380,14 @@ export function useOfframpBridge(): UseOfframpBridgeReturn {
                 setError("No valid quote available. Please check your input.");
                 return;
             }
+            if (isLoadingProviderMinimum) {
+                setError("Provider minimum is still loading. Please try again.");
+                return;
+            }
 
             const amount = parseFloat(form.amount);
-            const selectedToken = SUPPORTED_OFFRAMP_TOKENS.find(t => t.symbol === form.token);
-            if (selectedToken && amount < selectedToken.minimumAmount) {
-                setError(`Amount must be at least ${selectedToken.minimumAmount} ${selectedToken.symbol}`);
+            if (amount < providerMinimumAmount) {
+                setError(`Amount must be at least ${providerMinimumAmount} ${form.token}`);
                 return;
             }
 
@@ -391,7 +442,14 @@ export function useOfframpBridge(): UseOfframpBridgeReturn {
                 if (!controller.signal.aborted) setIsLoading(false);
             }
         },
-        [isConnected, address, quote, userLimits]
+        [
+            isConnected,
+            address,
+            quote,
+            userLimits,
+            providerMinimumAmount,
+            isLoadingProviderMinimum,
+        ]
     );
 
     // ---------- Confirm & Process ----------
@@ -499,5 +557,7 @@ export function useOfframpBridge(): UseOfframpBridgeReturn {
         isLoadingBanks,
         userLimits,
         isLoadingLimits,
+        providerMinimumAmount,
+        isLoadingProviderMinimum,
     };
 }

--- a/apps/web/src/services/offramp.mock.ts
+++ b/apps/web/src/services/offramp.mock.ts
@@ -5,6 +5,7 @@ import type {
   CreateOfframpResponse,
   OfframpCountry,
   ProviderRate,
+  ProviderLimitsResponse,
   QuoteStatusResponse,
   UserLimitsResponse,
   VerifyBankAccountResponse,
@@ -340,6 +341,28 @@ export const mockOfframpService = {
         dailyUsed: mockDailyUsed,
         remainingDaily: mockDailyLimit - mockDailyUsed,
         tier: "standard",
+      },
+    };
+  },
+
+  async getProviderLimits(
+    params: {
+      token: string;
+      country: string;
+      network: string;
+    },
+    signal?: AbortSignal,
+  ): Promise<ProviderLimitsResponse> {
+    await sleep(getMockDelay("sync"), signal);
+    const minimumAmount = params.country === "NG" ? 10 : 5;
+    return {
+      success: true,
+      data: {
+        minimumAmount,
+        providers: [
+          { providerId: "cashwyre", minimumAmount },
+          { providerId: "autoramp", minimumAmount },
+        ],
       },
     };
   },

--- a/apps/web/src/services/offramp.service.test.ts
+++ b/apps/web/src/services/offramp.service.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("offrampService.getProviderLimits", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.stubEnv("NEXT_PUBLIC_BACKEND_BASE_URL", "https://api.example.com");
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.unstubAllGlobals();
+    });
+
+    it("fetches provider limits for the selected corridor", async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    data: {
+                        minimumAmount: 25,
+                        providers: [
+                            { providerId: "cashwyre", minimumAmount: 25 },
+                        ],
+                    },
+                }),
+                {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }
+            )
+        );
+        vi.stubGlobal("fetch", fetchMock);
+        const { offrampService } = await import("./offramp.service");
+
+        const result = await offrampService.getProviderLimits({
+            token: "USDC",
+            country: "NG",
+            network: "polygon",
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://api.example.com/api/offramp/limits?token=USDC&country=NG&network=polygon",
+            expect.objectContaining({ method: "GET" })
+        );
+        expect(result).toEqual({
+            success: true,
+            data: {
+                minimumAmount: 25,
+                providers: [
+                    { providerId: "cashwyre", minimumAmount: 25 },
+                ],
+            },
+        });
+    });
+
+    it("rejects malformed minimum values instead of trusting them", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValue(
+                new Response(JSON.stringify({ data: { minimumAmount: "25" } }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                })
+            )
+        );
+        const { offrampService } = await import("./offramp.service");
+
+        const result = await offrampService.getProviderLimits({
+            token: "USDC",
+            country: "NG",
+            network: "polygon",
+        });
+
+        expect(result).toEqual({
+            success: false,
+            error: "Provider limits response did not include a valid minimum amount",
+        });
+    });
+
+    it("derives the usable minimum from provider-specific limits", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        data: {
+                            providers: [
+                                { providerId: "cashwyre", minimumAmount: 10 },
+                                { providerId: "autoramp", minimumAmount: 5 },
+                            ],
+                        },
+                    }),
+                    {
+                        status: 200,
+                        headers: { "Content-Type": "application/json" },
+                    }
+                )
+            )
+        );
+        const { offrampService } = await import("./offramp.service");
+
+        const result = await offrampService.getProviderLimits({
+            token: "USDC",
+            country: "GH",
+            network: "polygon",
+        });
+
+        expect(result.data?.minimumAmount).toBe(5);
+    });
+});

--- a/apps/web/src/services/offramp.service.ts
+++ b/apps/web/src/services/offramp.service.ts
@@ -10,6 +10,7 @@ import type {
     CreateOfframpResponse,
     QuoteStatusResponse,
     UserLimitsResponse,
+    ProviderLimitsResponse,
 } from "@/types/offramp";
 import { withRetry, RetryableError, isAbortError } from "@/utils/retry";
 import {
@@ -311,6 +312,82 @@ const realOfframpService = {
             return {
                 success: false,
                 error: error instanceof Error ? error.message : "Failed to fetch user limits",
+            };
+        }
+    },
+
+    async getProviderLimits(
+        params: {
+            token: string;
+            country: string;
+            network: string;
+        },
+        signal?: AbortSignal
+    ): Promise<ProviderLimitsResponse> {
+        try {
+            const queryParams = new URLSearchParams(params);
+            const res = await fetchWithRetry(
+                `${OFFRAMP_API_BASE}/limits?${queryParams}`,
+                {
+                    method: "GET",
+                    headers: getHeaders(),
+                },
+                signal
+            );
+
+            const data = await res.json();
+
+            if (!res.ok) {
+                return {
+                    success: false,
+                    error: data.message || data.error || "Failed to fetch provider limits",
+                };
+            }
+
+            const limits = data.data || data;
+            const providers = Array.isArray(limits.providers)
+                ? limits.providers.filter(
+                    (provider: unknown) =>
+                        typeof provider === "object" &&
+                        provider !== null &&
+                        "providerId" in provider &&
+                        typeof provider.providerId === "string" &&
+                        "minimumAmount" in provider &&
+                        typeof provider.minimumAmount === "number" &&
+                        Number.isFinite(provider.minimumAmount) &&
+                        provider.minimumAmount >= 0
+                )
+                : [];
+            const aggregateMinimum =
+                typeof limits.minimumAmount === "number" &&
+                Number.isFinite(limits.minimumAmount) &&
+                limits.minimumAmount >= 0
+                    ? limits.minimumAmount
+                    : providers.length > 0
+                        ? Math.min(...providers.map((provider) => provider.minimumAmount))
+                        : null;
+
+            if (aggregateMinimum === null) {
+                return {
+                    success: false,
+                    error: "Provider limits response did not include a valid minimum amount",
+                };
+            }
+
+            return {
+                success: true,
+                data: {
+                    minimumAmount: aggregateMinimum,
+                    providers,
+                },
+            };
+        } catch (error) {
+            if (isAbortError(error)) {
+                throw error;
+            }
+            return {
+                success: false,
+                error: error instanceof Error ? error.message : "Failed to fetch provider limits",
             };
         }
     },

--- a/apps/web/src/types/offramp.ts
+++ b/apps/web/src/types/offramp.ts
@@ -123,6 +123,20 @@ export interface AggregatedRatesResponse {
     error?: string;
 }
 
+export interface ProviderLimit {
+    providerId: string;
+    minimumAmount: number;
+}
+
+export interface ProviderLimitsResponse {
+    success: boolean;
+    data?: {
+        minimumAmount: number;
+        providers: ProviderLimit[];
+    };
+    error?: string;
+}
+
 export interface CreateOfframpRequest {
     providerId: OfframpProviderId;
     token: string;


### PR DESCRIPTION
## Summary

- fetch provider minimums from `/api/offramp/limits` for the selected token, country, and network
- normalize either an aggregate minimum or provider-specific minimums and reject malformed values
- abort stale requests when the corridor changes and retain the token minimum as a graceful fallback
- show the loading/dynamic minimum in `OfframpForm` and enforce the same value before creating an offramp
- extend the mock service and add component, service, fallback, and validation coverage

## Why

The form label and submission guard both read a static token configuration value, so provider-side minimum changes can leave the UI and actual service requirements out of sync. The provider limits service is now the source of truth, while the existing token value is used only when that service is unavailable.

## Validation

- targeted Offramp component, service, hook, and rate-limit suites: 30 tests passed
- ESLint passed for the changed component, service, mock, type, and new test files
- `git diff --check`

The full web suite currently reports 363 passing tests and 15 unrelated existing failures in `sanitize-error` and Stellar service tests. The repository-wide TypeScript check also remains blocked by existing errors outside this change.

Closes #444


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-specific minimum withdrawal amounts based on the selected token and country.
  * Off-ramp forms now display the applicable minimum or a loading message.
  * Withdrawals below the provider minimum are blocked with an error.
  * Added fallback handling when provider limit information is unavailable.

* **Tests**
  * Added coverage for minimum amount display, validation, loading states, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->