### PR TITLE
feat(web): add S3 presigned URL generator for campaign evidence uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,17 @@ TESTNET_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 
 # Optional: Custom network passphrases
 MAINNET_NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
+
+# ---------------------------------------------------------------------------
+# S3 presigned uploads — POST /api/presign-upload
+# Generates short-lived pre-signed PUT URLs for milestone proof photos.
+# The IAM user needs s3:PutObject on the evidence bucket (private by default).
+# ---------------------------------------------------------------------------
+AWS_REGION=us-east-1
+AWS_S3_BUCKET=your-evidence-bucket
+AWS_ACCESS_KEY_ID=your_access_key_id
+AWS_SECRET_ACCESS_KEY=your_secret_access_key
+# Optional STS session token for temporary credentials
+# AWS_SESSION_TOKEN=
+# URL lifetime in seconds (bounded 60..900, default 300)
+S3_PRESIGN_EXPIRES_SECONDS=300

--- a/README.md
+++ b/README.md
@@ -153,6 +153,36 @@ async function createNewStream() {
 }
 ```
 
+### 🔐 S3 Presigned Uploads (Milestone Proof Photos)
+
+`POST /api/presign-upload` generates a short-lived AWS S3 pre-signed PUT URL so clients can upload milestone proof photos directly to a **private** evidence bucket without exposing credentials. Signing uses AWS Signature V4 and is implemented dependency-free in `apps/web/src/lib/s3`.
+
+Request:
+
+```bash
+curl -X POST http://localhost:3000/api/presign-upload \
+  -H "Content-Type: application/json" \
+  -d '{"campaignId":"42","milestoneId":"1","contentType":"image/jpeg"}'
+```
+
+Response (`200`):
+
+```json
+{
+  "url": "https://fundable-evidence.s3.us-east-1.amazonaws.com/evidence/42/1/<uuid>.jpg?X-Amz-Algorithm=...&X-Amz-Signature=...",
+  "key": "evidence/42/1/<uuid>.jpg",
+  "contentType": "image/jpeg",
+  "expiresAt": 1712000000,
+  "requestId": "..."
+}
+```
+
+Then `PUT` the file bytes to `url` with `Content-Type: image/jpeg`. URLs expire after `S3_PRESIGN_EXPIRES_SECONDS` (default `300`).
+
+Allowed content types: `image/jpeg`, `image/png`, `image/webp`, `image/heic`, `application/pdf`.
+
+Required environment variables (see `.env.example`): `AWS_REGION`, `AWS_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`; optional `AWS_SESSION_TOKEN` (temporary STS credentials) and `S3_PRESIGN_EXPIRES_SECONDS` (60–900). The IAM user needs only `s3:PutObject` on the evidence bucket.
+
 ## 📦 Packages
 
 ### `apps/web`

--- a/apps/web/src/app/api/presign-upload/route.ts
+++ b/apps/web/src/app/api/presign-upload/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import {
+  ALLOWED_CONTENT_TYPES,
+  createPresignedPutUrl,
+  loadS3Config,
+  buildEvidenceKey,
+  type AllowedContentType,
+} from "@/lib/s3";
+
+/**
+ * POST /api/presign-upload
+ *
+ * Generates a short-lived pre-signed AWS S3 PUT URL for a milestone proof
+ * photo. The client uploads the photo directly to S3; the URL expires
+ * within the configured window (default 5 minutes) so credentials never
+ * reach the browser and the bucket stays private.
+ *
+ * Request body:
+ *   { "campaignId": "42", "milestoneId": "1", "contentType": "image/jpeg" }
+ *
+ * Response 200:
+ *   { "url": "...", "key": "...", "contentType": "...", "expiresAt": 1712... }
+ */
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const schema = z.object({
+    campaignId: z
+      .string()
+      .min(1, "campaignId is required")
+      .max(128, "campaignId is too long"),
+    milestoneId: z
+      .string()
+      .min(1, "milestoneId is required")
+      .max(128, "milestoneId is too long"),
+    contentType: z.enum(ALLOWED_CONTENT_TYPES),
+  });
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    const message = parsed.error.issues
+      .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+      .join("; ");
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  let config;
+  try {
+    config = loadS3Config();
+  } catch (error) {
+    console.error("[presign-upload] S3 configuration error", error);
+    return NextResponse.json(
+      { error: "S3 uploads are not configured" },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const key = buildEvidenceKey(
+      parsed.data.campaignId,
+      parsed.data.milestoneId,
+      parsed.data.contentType as AllowedContentType,
+    );
+    const result = createPresignedPutUrl(config, {
+      key,
+      contentType: parsed.data.contentType as AllowedContentType,
+    });
+
+    return NextResponse.json({
+      url: result.url,
+      key: result.key,
+      contentType: result.contentType,
+      expiresAt: result.expiresAt,
+      requestId: result.requestId,
+    });
+  } catch (error) {
+    console.error("[presign-upload] presigning error", error);
+    return NextResponse.json(
+      { error: "Failed to generate upload URL" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/lib/s3/config.ts
+++ b/apps/web/src/lib/s3/config.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+/**
+ * Server-only S3 configuration for the presigned-upload endpoint.
+ *
+ * These values are read from the server environment at request time (never
+ * exposed to the client bundle) and validated with zod so misconfiguration
+ * fails loudly instead of producing broken URLs at runtime.
+ */
+export const s3ConfigSchema = z.object({
+  /** AWS region hosting the evidence bucket, e.g. "us-east-1". */
+  AWS_REGION: z.string().min(1, "AWS_REGION is required"),
+  /** S3 bucket that stores milestone proof photos (private by default). */
+  AWS_S3_BUCKET: z.string().min(1, "AWS_S3_BUCKET is required"),
+  /** IAM access key with `s3:PutObject` on the evidence bucket. */
+  AWS_ACCESS_KEY_ID: z.string().min(1, "AWS_ACCESS_KEY_ID is required"),
+  /** IAM secret access key. */
+  AWS_SECRET_ACCESS_KEY: z.string().min(1, "AWS_SECRET_ACCESS_KEY is required"),
+  /** Optional STS session token for temporary credentials. */
+  AWS_SESSION_TOKEN: z.string().optional(),
+  /**
+   * URL presign lifetime in seconds. Bounded to 60..900 so the window is
+   * short-lived but large enough for a multi-megabyte photo upload.
+   */
+  S3_PRESIGN_EXPIRES_SECONDS: z.coerce
+    .number()
+    .int("must be an integer")
+    .min(60, "presign lifetime must be at least 60s")
+    .max(900, "presign lifetime must be at most 900s")
+    .default(300),
+});
+
+export type S3Config = z.infer<typeof s3ConfigSchema>;
+
+/**
+ * Validate the server S3 environment and return a typed config object.
+ *
+ * @returns typed S3 configuration
+ * @throws {Error} when any required S3 variable is missing or invalid
+ */
+export function loadS3Config(env: NodeJS.ProcessEnv = process.env): S3Config {
+  const parsed = s3ConfigSchema.safeParse(env);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((issue) => `  - ${issue.path.join(".")}: ${issue.message}`)
+      .join("\n");
+    throw new Error(`S3 configuration is invalid:\n${issues}`);
+  }
+  return parsed.data;
+}

--- a/apps/web/src/lib/s3/index.ts
+++ b/apps/web/src/lib/s3/index.ts
@@ -1,0 +1,11 @@
+export { s3ConfigSchema, loadS3Config, type S3Config } from "./config";
+export {
+  createPresignedPutUrl,
+  awsUriEncode,
+  ALLOWED_CONTENT_TYPES,
+  MAX_KEY_LENGTH,
+  type AllowedContentType,
+  type PresignUploadRequest,
+  type PresignUploadResult,
+} from "./presigner";
+export { buildEvidenceKey, extensionForContentType } from "./keys";

--- a/apps/web/src/lib/s3/keys.ts
+++ b/apps/web/src/lib/s3/keys.ts
@@ -1,0 +1,41 @@
+import { randomUUID } from "node:crypto";
+import { MAX_KEY_LENGTH, type AllowedContentType } from "./presigner";
+
+/**
+ * Build a safe, namespaced object key for a milestone proof photo.
+ *
+ * The key is derived entirely from server-side input (campaign/milestone ids
+ * and a generated UUID) plus a validated content type, so user-supplied file
+ * names never reach the S3 key and cannot traverse directories.
+ *
+ * @param campaignId on-chain campaign / stream id (numeric string)
+ * @param milestoneId milestone index within the campaign
+ * @param contentType validated MIME type used to derive the file extension
+ */
+export function buildEvidenceKey(
+  campaignId: string,
+  milestoneId: string,
+  contentType: AllowedContentType,
+): string {
+  const ext = extensionForContentType(contentType);
+  const normalizedCampaign = String(campaignId).replace(/[^a-zA-Z0-9_-]/g, "");
+  const normalizedMilestone = String(milestoneId).replace(/[^a-zA-Z0-9_-]/g, "");
+  const key = `evidence/${normalizedCampaign}/${normalizedMilestone}/${randomUUID()}.${ext}`;
+
+  if (key.length > MAX_KEY_LENGTH) {
+    throw new Error(`Generated evidence key exceeds max length (${MAX_KEY_LENGTH})`);
+  }
+  return key;
+}
+
+const EXTENSIONS: Record<AllowedContentType, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/heic": "heic",
+  "application/pdf": "pdf",
+};
+
+export function extensionForContentType(contentType: AllowedContentType): string {
+  return EXTENSIONS[contentType];
+}

--- a/apps/web/src/lib/s3/presigner.test.ts
+++ b/apps/web/src/lib/s3/presigner.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import {
+  createPresignedPutUrl,
+  awsUriEncode,
+  buildEvidenceKey,
+  extensionForContentType,
+} from "./index";
+import { loadS3Config, s3ConfigSchema } from "./config";
+import type { S3Config } from "./config";
+
+const FIXED_NOW = 1_700_000_000; // deterministic "now" for stable signatures
+
+function testConfig(overrides: Partial<S3Config> = {}): S3Config {
+  return {
+    AWS_REGION: "us-east-1",
+    AWS_S3_BUCKET: "fundable-evidence",
+    AWS_ACCESS_KEY_ID: "AKIAIOSFODNN7EXAMPLE",
+    AWS_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    S3_PRESIGN_EXPIRES_SECONDS: 300,
+    ...overrides,
+  };
+}
+
+describe("awsUriEncode", () => {
+  it("preserves unreserved characters", () => {
+    expect(awsUriEncode("abcXYZ012-._~")).toBe("abcXYZ012-._~");
+  });
+
+  it("upper-hex encodes reserved characters", () => {
+    expect(awsUriEncode("a b+c")).toBe("a%20b%2Bc");
+  });
+
+  it("keeps slashes unencoded by default", () => {
+    expect(awsUriEncode("evidence/1/2")).toBe("evidence/1/2");
+  });
+});
+
+describe("createPresignedPutUrl", () => {
+  it("produces a signed PUT url with expected query parameters", () => {
+    const result = createPresignedPutUrl(
+      testConfig(),
+      { key: "evidence/42/1/uuid.jpg", contentType: "image/jpeg" },
+      FIXED_NOW,
+    );
+
+    const url = new URL(result.url);
+    expect(url.protocol).toBe("https:");
+    expect(url.hostname).toBe("fundable-evidence.s3.us-east-1.amazonaws.com");
+    expect(url.searchParams.get("X-Amz-Algorithm")).toBe("AWS4-HMAC-SHA256");
+    expect(url.searchParams.get("X-Amz-Credential")).toContain(
+      "AKIAIOSFODNN7EXAMPLE/",
+    );
+    expect(url.searchParams.get("X-Amz-SignedHeaders")).toBe("host");
+    expect(url.searchParams.get("X-Amz-Expires")).toBe("300");
+    expect(url.searchParams.get("X-Amz-Signature")).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("returns the object key, content type and expiry metadata", () => {
+    const result = createPresignedPutUrl(
+      testConfig(),
+      { key: "evidence/42/1/uuid.jpg", contentType: "image/png" },
+      FIXED_NOW,
+    );
+    expect(result.key).toBe("evidence/42/1/uuid.jpg");
+    expect(result.contentType).toBe("image/png");
+    expect(result.expiresAt).toBe(FIXED_NOW + 300);
+    expect(result.requestId).toBeTruthy();
+  });
+
+  it("signature changes when the key changes (request is bound to the key)", () => {
+    const base = testConfig();
+    const a = createPresignedPutUrl(
+      base,
+      { key: "evidence/1/1/a.jpg", contentType: "image/jpeg" },
+      FIXED_NOW,
+    );
+    const b = createPresignedPutUrl(
+      base,
+      { key: "evidence/1/1/b.jpg", contentType: "image/jpeg" },
+      FIXED_NOW,
+    );
+    expect(a.url).not.toBe(b.url);
+  });
+
+  it("signature changes when the secret changes", () => {
+    const a = createPresignedPutUrl(
+      testConfig(),
+      { key: "evidence/1/1/a.jpg", contentType: "image/jpeg" },
+      FIXED_NOW,
+    );
+    const b = createPresignedPutUrl(
+      testConfig({ AWS_SECRET_ACCESS_KEY: "different-secret-key-value" }),
+      { key: "evidence/1/1/a.jpg", contentType: "image/jpeg" },
+      FIXED_NOW,
+    );
+    expect(a.url).not.toBe(b.url);
+  });
+
+  it("includes the session token when temporary credentials are configured", () => {
+    const result = createPresignedPutUrl(
+      testConfig({ AWS_SESSION_TOKEN: "FwoGZXIvYXdzEF0EXAMPLE" }),
+      { key: "evidence/1/1/a.jpg", contentType: "image/jpeg" },
+      FIXED_NOW,
+    );
+    const url = new URL(result.url);
+    expect(url.searchParams.get("X-Amz-Security-Token")).toBe(
+      "FwoGZXIvYXdzEF0EXAMPLE",
+    );
+  });
+
+  it("clamps a requested lifetime to the configured maximum", () => {
+    const config = testConfig({ S3_PRESIGN_EXPIRES_SECONDS: 300 });
+    const result = createPresignedPutUrl(
+      config,
+      { key: "evidence/1/1/a.jpg", contentType: "image/jpeg", expiresInSeconds: 3600 },
+      FIXED_NOW,
+    );
+    const url = new URL(result.url);
+    expect(url.searchParams.get("X-Amz-Expires")).toBe("300");
+    expect(result.expiresAt).toBe(FIXED_NOW + 300);
+  });
+
+  it("honours the configured default lifetime", () => {
+    const result = createPresignedPutUrl(
+      testConfig({ S3_PRESIGN_EXPIRES_SECONDS: 600 }),
+      { key: "evidence/1/1/a.jpg", contentType: "image/jpeg" },
+      FIXED_NOW,
+    );
+    const url = new URL(result.url);
+    expect(url.searchParams.get("X-Amz-Expires")).toBe("600");
+  });
+});
+
+describe("buildEvidenceKey", () => {
+  it("namespaces the key under evidence/<campaign>/<milestone>", () => {
+    const key = buildEvidenceKey("42", "1", "image/jpeg");
+    expect(key).toMatch(/^evidence\/42\/1\/[0-9a-f-]{36}\.jpg$/);
+  });
+
+  it("uses the correct extension per content type", () => {
+    expect(extensionForContentType("image/png")).toBe("png");
+    expect(extensionForContentType("application/pdf")).toBe("pdf");
+    expect(buildEvidenceKey("42", "1", "image/webp")).toMatch(/\.webp$/);
+  });
+
+  it("sanitizes directory-traversal characters in ids", () => {
+    const key = buildEvidenceKey("../etc", "1", "image/jpeg");
+    expect(key).toMatch(/^evidence\/etc\/1\//);
+    expect(key).not.toContain("..");
+  });
+});
+
+describe("loadS3Config", () => {
+  it("parses a complete valid environment", () => {
+    const config = loadS3Config({
+      AWS_REGION: "eu-west-1",
+      AWS_S3_BUCKET: "bucket",
+      AWS_ACCESS_KEY_ID: "AKIA123",
+      AWS_SECRET_ACCESS_KEY: "secret",
+    } as NodeJS.ProcessEnv);
+    expect(config.AWS_REGION).toBe("eu-west-1");
+    expect(config.S3_PRESIGN_EXPIRES_SECONDS).toBe(300);
+  });
+
+  it("throws when required variables are missing", () => {
+    expect(() =>
+      loadS3Config({ AWS_REGION: "us-east-1" } as NodeJS.ProcessEnv),
+    ).toThrow(/AWS_S3_BUCKET/);
+  });
+
+  it("rejects an out-of-range expiry at the schema level", () => {
+    const result = s3ConfigSchema.safeParse({
+      AWS_REGION: "us-east-1",
+      AWS_S3_BUCKET: "bucket",
+      AWS_ACCESS_KEY_ID: "AKIA123",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      S3_PRESIGN_EXPIRES_SECONDS: "9999",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/web/src/lib/s3/presigner.ts
+++ b/apps/web/src/lib/s3/presigner.ts
@@ -1,0 +1,152 @@
+import { createHash, createHmac, randomUUID } from "node:crypto";
+import type { S3Config } from "./config";
+
+/**
+ * AWS Signature V4 pre-signed URL generator for private S3 uploads.
+ *
+ * This module produces short-lived PUT URLs for the milestone-evidence bucket
+ * so clients can upload photos directly to S3 without exposing bucket
+ * credentials. Signing is implemented locally (AWS SigV4) so the code is
+ * fully unit-testable offline and does not pull the full AWS SDK into the
+ * server bundle.
+ */
+
+/** Allowed content types for milestone proof photos. */
+export const ALLOWED_CONTENT_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+  "application/pdf",
+] as const;
+
+export type AllowedContentType = (typeof ALLOWED_CONTENT_TYPES)[number];
+
+/** Max object key length (S3 enforces 1024; we keep a tighter bound). */
+export const MAX_KEY_LENGTH = 512;
+
+export interface PresignUploadRequest {
+  /**
+   * Object key (path) inside the evidence bucket. Should be namespaced,
+   * e.g. `evidence/<campaignId>/<milestoneId>/<uuid>.<ext>`.
+   */
+  key: string;
+  /** MIME type of the file to be uploaded. Must be in {@link ALLOWED_CONTENT_TYPES}. */
+  contentType: AllowedContentType;
+  /** Requested URL lifetime in seconds (clamped to the configured max). */
+  expiresInSeconds?: number;
+}
+
+export interface PresignUploadResult {
+  /** HTTPS PUT URL the client should upload the photo to. */
+  url: string;
+  /** Object key the file was (or will be) written to. */
+  key: string;
+  /** Content type the upload must use so the object is served correctly. */
+  contentType: AllowedContentType;
+  /** Absolute expiry time (epoch seconds). */
+  expiresAt: number;
+  /** Request ID the caller can correlate with a backend record. */
+  requestId: string;
+}
+
+const HOST_HEADER = "host";
+const ALGORITHM = "AWS4-HMAC-SHA256";
+const SERVICE = "s3";
+const TERMINATOR = "aws4_request";
+
+/**
+ * Percent-encode a string per RFC 3986 with the S3-specific relaxed rules:
+ * unreserved characters are left as-is, everything else is upper-hex encoded.
+ */
+export function awsUriEncode(value: string, encodeSlash = false): string {
+  const encoded = encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+  return encodeSlash ? encoded : encoded.replace(/%2F/gi, "/");
+}
+
+/** Build the canonical (presign-safe) resource path for an S3 object. *//** Derive the per-service signing key. */
+function signingKey(secret: string, date: string, region: string): Buffer {
+  const dateKey = createHmac("sha256", `AWS4${secret}`).update(date).digest();
+  const regionKey = createHmac("sha256", dateKey).update(region).digest();
+  const serviceKey = createHmac("sha256", regionKey).update(SERVICE).digest();
+  return createHmac("sha256", serviceKey).update(TERMINATOR).digest();
+}
+
+function hmacHex(key: Buffer | string, value: string): string {
+  return createHmac("sha256", key).update(value).digest("hex");
+}
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+/**
+ * Generate a short-lived pre-signed PUT URL for a private S3 object.
+ *
+ * @param config validated S3 server configuration
+ * @param request object key, content type and requested lifetime
+ * @param now unix timestamp in seconds (injectable for deterministic tests)
+ */
+export function createPresignedPutUrl(
+  config: S3Config,
+  request: PresignUploadRequest,
+  now: number = Math.floor(Date.now() / 1000),
+): PresignUploadResult {
+  const bucket = config.AWS_S3_BUCKET;
+  const region = config.AWS_REGION;
+  const key = request.key;
+  const contentType = request.contentType;
+
+  const expiresIn = Math.min(
+    Math.max(60, request.expiresInSeconds ?? config.S3_PRESIGN_EXPIRES_SECONDS),
+    config.S3_PRESIGN_EXPIRES_SECONDS,
+  );
+
+  const amzDate = new Date(now * 1000).toISOString().replace(/[:-]|\.\d{3}/g, "");
+  const dateStamp = amzDate.slice(0, 8);
+  const credentialScope = `${dateStamp}/${region}/${SERVICE}/${TERMINATOR}`;
+
+  const canonicalUri = `/${awsUriEncode(key, true)}`;
+  const canonicalQuerystring = [
+    "X-Amz-Algorithm=AWS4-HMAC-SHA256",
+    `X-Amz-Credential=${awsUriEncode(`${config.AWS_ACCESS_KEY_ID}/${credentialScope}`)}`,
+    `X-Amz-Date=${amzDate}`,
+    `X-Amz-Expires=${expiresIn}`,
+    "X-Amz-SignedHeaders=host",
+    ...(config.AWS_SESSION_TOKEN
+      ? [`X-Amz-Security-Token=${awsUriEncode(config.AWS_SESSION_TOKEN)}`]
+      : []),
+  ].sort().join("&");
+
+  const canonicalHeaders = `${HOST_HEADER}:${bucket}.s3.${region}.amazonaws.com\n`;
+  const canonicalRequest = [
+    "PUT",
+    canonicalUri,
+    canonicalQuerystring,
+    canonicalHeaders,
+    "host",
+    "UNSIGNED-PAYLOAD",
+  ].join("\n");
+
+  const stringToSign = [
+    ALGORITHM,
+    amzDate,
+    credentialScope,
+    sha256Hex(canonicalRequest),
+  ].join("\n");
+
+  const signature = hmacHex(signingKey(config.AWS_SECRET_ACCESS_KEY, dateStamp, region), stringToSign);
+
+  const url = `https://${bucket}.s3.${region}.amazonaws.com/${key}?${canonicalQuerystring}&X-Amz-Signature=${signature}`;
+
+  return {
+    url,
+    key,
+    contentType,
+    expiresAt: now + expiresIn,
+    requestId: randomUUID(),
+  };
+}


### PR DESCRIPTION
**Category:** backend
**Project area:** apps/web/src/app/api/presign-upload/ and apps/web/src/lib/s3/

**Implementation:**
- Adds `POST /api/presign-upload` which generates short-lived pre-signed AWS S3 PUT URLs for milestone proof photo uploads.
- Dependency-free AWS Signature V4 presigner in `apps/web/src/lib/s3` (no AWS SDK dependency).
- Object keys are server-generated as `evidence/<campaignId>/<milestoneId>/<uuid>.<ext>`, sanitized against traversal; content-type allowlist (`image/jpeg`, `image/png`, `image/webp`, `image/heic`, `application/pdf`).
- Zod-validated env config: `AWS_REGION`, `AWS_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`, `S3_PRESIGN_EXPIRES_SECONDS` (60-900, default 300).
- Route error handling: 400 for validation, 503 when S3 is unconfigured, 500 with server-side logging.

**Acceptance Criteria:**
- Unit tests pass (`vitest run`): 16 tests covering SigV4 signing, session-token support, expiry clamping, key sanitization, and config validation.
- URL expires after the configured window and contains all required `X-Amz-*` query parameters.
- No credentials leak to the client; only a short-lived URL, key, content type, expiry, and request id are returned.
- Documentation updated in `README.md` and `.env.example`.

Closes #533


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating short-lived upload links for milestone evidence photos.
  * Supports private S3 uploads with validation for file types, identifiers, and expiration limits.
  * Upload responses include the destination details, expiration time, and request identifier.
* **Documentation**
  * Added setup instructions, configuration guidance, request and response examples, upload behavior, and required permissions.
* **Bug Fixes**
  * Added clear validation and service errors for invalid requests or incomplete storage configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->