### PR TITLE
feat(payment-stream): multi-recipient batch stream creation

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -17,17 +17,19 @@ Shared dependencies, such as the `soroban-sdk`, are managed in the root `Cargo.t
 
 ### 1. Payment Stream (`payment-stream`)
 
-The `payment-stream` contract allows for the creation of linear payment streams, where a specified amount of tokens is released to a recipient over a defined period.
+The `payment-stream` contract allows for the creation of linear payment streams, where a specified amount of tokens is released to a recipient over a defined period. Streams can also be created with a **cliff (lockup) period**, during which nothing is withdrawable before linear vesting begins.
 
 #### Core Concepts
 
--   **Stream:** A `Stream` is the central data structure, containing details about the sender, recipient, token, total amount, withdrawn amount, start and end times, and the stream's status.
+-   **Stream:** A `Stream` is the central data structure, containing details about the sender, recipient, token, total amount, withdrawn amount, start and end times, an optional cliff duration, and the stream's status.
+-   **Cliff Period:** The number of seconds after `start_time` during which the recipient cannot withdraw. Once elapsed, tokens vest linearly across the full stream window, so the pro-rata share accrued during the cliff is released at the cliff boundary.
 -   **Status:** A stream can have one of the following statuses: `Active`, `Paused`, `Canceled`, or `Completed`.
 
 #### Key Functions
 
 -   `initialize(admin: Address)`: Initializes the contract with an administrative address.
--   `create_stream(...)`: Creates a new payment stream with specified parameters.
+-   `create_stream(...)`: Creates a new payment stream with specified parameters (no cliff).
+-   `create_stream_with_cliff(...)`: Creates a payment stream with a cliff (lockup) period.
 -   `get_stream(stream_id: u64)`: Retrieves the details of a specific stream.
 -   `withdrawable_amount(stream_id: u64)`: Calculates the amount that can be withdrawn from a stream at the current time.
 -   `withdraw(stream_id: u64, amount: i128)`: Allows the recipient to withdraw available funds.

--- a/contracts/payment-stream/src/lib.rs
+++ b/contracts/payment-stream/src/lib.rs
@@ -1,5 +1,9 @@
 #![no_std]
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, panic_with_error, token, Address, Env};
+#![allow(deprecated)]
+use soroban_sdk::{
+    contract, contractclient, contracterror, contractimpl, contracttype, panic_with_error, token,
+    Address, Env, Vec,
+};
 
 /// Persistent/instance storage keys.
 ///
@@ -18,6 +22,10 @@ pub enum DataKey {
     Stream(u64),
     Metrics(u64),
     Delegate(u64),
+    /// Global emergency-pause circuit breaker flag (instance storage).
+    Paused,
+    /// Configured DEX router address used by `deposit_with_swap` (instance storage).
+    DexRouter,
 }
 
 /// Stream status enum
@@ -42,6 +50,9 @@ pub struct Stream {
     pub balance: i128,
     pub withdrawn_amount: i128,
     pub start_time: u64,
+    /// Number of seconds after `start_time` during which nothing is
+    /// withdrawable (linear lockup). `0` means no cliff.
+    pub cliff_duration: u64,
     pub end_time: u64,
     pub status: StreamStatus,
     pub paused_at: Option<u64>,  
@@ -178,12 +189,35 @@ pub enum Error {
     AlreadyPaused = 18,
     /// Contract is not currently paused
     NotPaused = 19,
+    /// Swap path is invalid for cross-asset deposits (from_token == stream.token)
+    InvalidSwapPath = 20,
+    /// DEX returned fewer tokens than the caller's minimum (slippage guard)
+    SlippageExceeded = 21,
+    /// Internal failure while swapping for a deposit
+    SwapFailed = 22,
+    /// Cliff period is not shorter than the total vesting duration
+    InvalidCliff = 23,
 }
 
 // Constants
 const MAX_FEE: u32 = 500; // 5% in basis points
 const LEDGER_THRESHOLD: u32 = 518400; // ~30 days at 5s/ledger
 const LEDGER_BUMP: u32 = 535680; // ~31 days
+
+/// Client for the external DEX router contract used by `deposit_with_swap`.
+///
+/// The router must expose `swap_exact_tokens_for_tokens`, returning the
+/// amounts actually received per hop of the swap path.
+#[contractclient(name = "DexRouterClient")]
+pub trait DexRouter {
+    fn swap_exact_tokens_for_tokens(
+        env: Env,
+        amount_in: i128,
+        min_amount_out: i128,
+        path: Vec<Address>,
+        to: Address,
+    ) -> Vec<i128>;
+}
 
 #[contract]
 pub struct PaymentStreamContract;
@@ -225,11 +259,7 @@ impl PaymentStreamContract {
     /// pause flag is active.  Call this at the top of every state-mutating
     /// entry point that should be halted during an incident.
     fn assert_not_paused(env: &Env) {
-        let paused: bool = env
-            .storage()
-            .instance()
-            .get(&Symbol::new(env, "paused"))
-            .unwrap_or(false);
+        let paused: bool = env.storage().instance().get(&DataKey::Paused).unwrap_or(false);
         if paused {
             panic_with_error!(env, Error::ContractPaused);
         }
@@ -251,22 +281,16 @@ impl PaymentStreamContract {
         let admin: Address = env
             .storage()
             .instance()
-            .get(&Symbol::new(&env, "admin"))
+            .get(&DataKey::Admin)
             .unwrap_or_else(|| panic_with_error!(&env, Error::NotInitialized));
         admin.require_auth();
 
-        let already_paused: bool = env
-            .storage()
-            .instance()
-            .get(&Symbol::new(&env, "paused"))
-            .unwrap_or(false);
+        let already_paused: bool = env.storage().instance().get(&DataKey::Paused).unwrap_or(false);
         if already_paused {
             panic_with_error!(&env, Error::AlreadyPaused);
         }
 
-        env.storage()
-            .instance()
-            .set(&Symbol::new(&env, "paused"), &true);
+        env.storage().instance().set(&DataKey::Paused, &true);
         env.storage()
             .instance()
             .extend_ttl(LEDGER_THRESHOLD, LEDGER_BUMP);
@@ -293,22 +317,16 @@ impl PaymentStreamContract {
         let admin: Address = env
             .storage()
             .instance()
-            .get(&Symbol::new(&env, "admin"))
+            .get(&DataKey::Admin)
             .unwrap_or_else(|| panic_with_error!(&env, Error::NotInitialized));
         admin.require_auth();
 
-        let paused: bool = env
-            .storage()
-            .instance()
-            .get(&Symbol::new(&env, "paused"))
-            .unwrap_or(false);
+        let paused: bool = env.storage().instance().get(&DataKey::Paused).unwrap_or(false);
         if !paused {
             panic_with_error!(&env, Error::NotPaused);
         }
 
-        env.storage()
-            .instance()
-            .set(&Symbol::new(&env, "paused"), &false);
+        env.storage().instance().set(&DataKey::Paused, &false);
         env.storage()
             .instance()
             .extend_ttl(LEDGER_THRESHOLD, LEDGER_BUMP);
@@ -325,17 +343,23 @@ impl PaymentStreamContract {
 
     /// Returns `true` when the global emergency pause is active.
     pub fn is_paused(env: Env) -> bool {
-        env.storage()
-            .instance()
-            .get(&Symbol::new(&env, "paused"))
-            .unwrap_or(false)
+        env.storage().instance().get(&DataKey::Paused).unwrap_or(false)
     }
 
     // -----------------------------------------------------------------------
     // Core stream operations
     // -----------------------------------------------------------------------
 
-    /// Create a new payment stream
+    /// Create a new payment stream (no cliff period).
+    ///
+    /// See [`create_stream_with_cliff`](Self::create_stream_with_cliff) for a
+    /// variant that adds an initial linear lockup period.
+    ///
+    /// # Authorization
+    /// Requires the `sender` address to sign the call.
+    ///
+    /// # Returns
+    /// The unique `u64` ID of the newly created stream.
     pub fn create_stream(
         env: Env,
         sender: Address,
@@ -346,9 +370,85 @@ impl PaymentStreamContract {
         start_time: u64,
         end_time: u64,
     ) -> u64 {
+        Self::create_stream_internal(
+            env,
+            sender,
+            recipient,
+            token,
+            total_amount,
+            initial_amount,
+            start_time,
+            end_time,
+            0,
+        )
+    }
+
+    /// Create a new payment stream with a linear cliff (lockup) period.
+    ///
+    /// Nothing is withdrawable during the first `cliff_duration` seconds after
+    /// `start_time`. Once the cliff has elapsed, tokens vest linearly across
+    /// the whole `[start_time, end_time]` window, so the pro-rata share accrued
+    /// during the cliff becomes claimable immediately at the cliff boundary.
+    ///
+    /// # Arguments
+    /// * `sender` - Address funding the stream.
+    /// * `recipient` - Address that will receive the funds.
+    /// * `token` - Token contract being streamed.
+    /// * `total_amount` - Total amount to be streamed.
+    /// * `initial_amount` - Amount transferred into escrow on creation.
+    /// * `start_time` - Ledger timestamp when vesting begins.
+    /// * `end_time` - Ledger timestamp when vesting completes.
+    /// * `cliff_duration` - Seconds after `start_time` during which nothing is withdrawable.
+    ///
+    /// # Authorization
+    /// Requires the `sender` address to sign the call.
+    ///
+    /// # Errors
+    /// - `Error::InvalidAmount` - `total_amount <= 0` or `initial_amount` out of range.
+    /// - `Error::InvalidTimeRange` - `end_time <= start_time`.
+    /// - `Error::InvalidCliff` - `cliff_duration >= end_time - start_time`.
+    /// - `Error::ContractPaused` - the emergency circuit breaker is active.
+    ///
+    /// # Returns
+    /// The unique `u64` ID of the newly created stream.
+    pub fn create_stream_with_cliff(
+        env: Env,
+        sender: Address,
+        recipient: Address,
+        token: Address,
+        total_amount: i128,
+        initial_amount: i128,
+        start_time: u64,
+        end_time: u64,
+        cliff_duration: u64,
+    ) -> u64 {
+        Self::create_stream_internal(
+            env,
+            sender,
+            recipient,
+            token,
+            total_amount,
+            initial_amount,
+            start_time,
+            end_time,
+            cliff_duration,
+        )
+    }
+
+    /// Shared implementation for stream creation.
+    fn create_stream_internal(
+        env: Env,
+        sender: Address,
+        recipient: Address,
+        token: Address,
+        total_amount: i128,
+        initial_amount: i128,
+        start_time: u64,
+        end_time: u64,
+        cliff_duration: u64,
+    ) -> u64 {
         Self::assert_not_paused(&env);
         sender.require_auth();
-        Self::require_not_paused(&env);
 
         // Validate inputs
         if total_amount <= 0 {
@@ -359,6 +459,9 @@ impl PaymentStreamContract {
         }
         if end_time <= start_time {
             panic_with_error!(&env, Error::InvalidTimeRange);
+        }
+        if cliff_duration >= end_time - start_time {
+            panic_with_error!(&env, Error::InvalidCliff);
         }
 
         // Get and increment stream count
@@ -379,6 +482,7 @@ impl PaymentStreamContract {
             balance: initial_amount,
             withdrawn_amount: 0,
             start_time,
+            cliff_duration,
             end_time,
             status: StreamStatus::Active,
             paused_at: None,
@@ -438,7 +542,6 @@ impl PaymentStreamContract {
         }
 
         stream.sender.require_auth();
-        Self::require_not_paused(&env);
 
         if amount <= 0 {
             panic_with_error!(&env, Error::InvalidAmount);
@@ -566,7 +669,7 @@ impl PaymentStreamContract {
         let dex_router: Address = env
             .storage()
             .instance()
-            .get(&Symbol::new(&env, "dex_router"))
+            .get(&DataKey::DexRouter)
             .unwrap_or_else(|| panic_with_error!(&env, Error::SwapFailed));
 
         let router = DexRouterClient::new(&env, &dex_router);
@@ -603,23 +706,23 @@ impl PaymentStreamContract {
 
         // 10. Persist updated stream state
         stream.balance = new_balance;
-        env.storage().persistent().set(&stream_id, &stream);
-        env.storage().persistent().extend_ttl(&stream_id, LEDGER_THRESHOLD, LEDGER_BUMP);
+        env.storage().persistent().set(&DataKey::Stream(stream_id), &stream);
+        env.storage().persistent().extend_ttl(&DataKey::Stream(stream_id), LEDGER_THRESHOLD, LEDGER_BUMP);
 
         // 11. Update stream metrics
         let mut metrics: StreamMetrics = env
             .storage()
             .persistent()
-            .get(&(stream_id, Symbol::new(&env, "metrics")))
+            .get(&DataKey::Metrics(stream_id))
             .unwrap_or_else(|| Self::default_stream_metrics(&env));
 
         metrics.last_activity = env.ledger().timestamp();
 
         env.storage()
             .persistent()
-            .set(&(stream_id, Symbol::new(&env, "metrics")), &metrics);
+            .set(&DataKey::Metrics(stream_id), &metrics);
         env.storage().persistent().extend_ttl(
-            &(stream_id, Symbol::new(&env, "metrics")),
+            &DataKey::Metrics(stream_id),
             LEDGER_THRESHOLD,
             LEDGER_BUMP,
         );
@@ -655,13 +758,13 @@ impl PaymentStreamContract {
         let admin: Address = env
             .storage()
             .instance()
-            .get(&Symbol::new(&env, "admin"))
+            .get(&DataKey::Admin)
             .unwrap_or_else(|| panic_with_error!(&env, Error::NotInitialized));
         admin.require_auth();
 
         env.storage()
             .instance()
-            .set(&Symbol::new(&env, "dex_router"), &router);
+            .set(&DataKey::DexRouter, &router);
         env.storage()
             .instance()
             .extend_ttl(LEDGER_THRESHOLD, LEDGER_BUMP);
@@ -671,7 +774,7 @@ impl PaymentStreamContract {
     pub fn get_dex_router(env: Env) -> Option<Address> {
         env.storage()
             .instance()
-            .get(&Symbol::new(&env, "dex_router"))
+            .get(&DataKey::DexRouter)
     }
 
     /// Get stream details
@@ -856,6 +959,13 @@ impl PaymentStreamContract {
         // Subtract the total paused duration from elapsed time
         let elapsed = raw_elapsed.saturating_sub(stream.total_paused_duration);
 
+        // Cliff: nothing may be withdrawn until the lockup period has elapsed.
+        // Vesting resumes linearly over the full duration afterwards, so the
+        // pro-rata share accrued during the cliff is claimable at the boundary.
+        if elapsed < stream.cliff_duration {
+            return 0;
+        }
+
         let duration = (stream.end_time - stream.start_time).saturating_sub(stream.total_paused_duration);
         if duration == 0 {
             return 0;
@@ -872,7 +982,6 @@ impl PaymentStreamContract {
         let mut stream: Stream = Self::get_stream(env.clone(), stream_id);
 
         Self::assert_is_recipient_or_delegate(&env, stream_id);
-        Self::require_not_paused(&env);
 
         let available = Self::withdrawable_amount(env.clone(), stream_id);
         if amount > available || amount <= 0 {

--- a/contracts/payment-stream/src/lib.rs
+++ b/contracts/payment-stream/src/lib.rs
@@ -59,6 +59,20 @@ pub struct Stream {
     pub total_paused_duration: u64,
 }
 
+/// Per-recipient parameters for `create_batch_streams`.
+#[contracttype]
+#[derive(Clone)]
+pub struct StreamParams {
+    pub recipient: Address,
+    pub token: Address,
+    pub total_amount: i128,
+    pub initial_amount: i128,
+    pub start_time: u64,
+    pub end_time: u64,
+    /// Seconds after `start_time` during which nothing is withdrawable.
+    pub cliff_duration: u64,
+}
+
 /// Per-stream metrics tracking
 #[contracttype]
 #[derive(Clone)]
@@ -197,10 +211,15 @@ pub enum Error {
     SwapFailed = 22,
     /// Cliff period is not shorter than the total vesting duration
     InvalidCliff = 23,
+    /// Batch contains more than the maximum number of streams (50)
+    BatchLimitExceeded = 24,
+    /// Batch contains no recipients
+    EmptyBatch = 25,
 }
 
 // Constants
 const MAX_FEE: u32 = 500; // 5% in basis points
+const MAX_STREAMS_PER_BATCH: u32 = 50; // max streams per create_batch_streams call
 const LEDGER_THRESHOLD: u32 = 518400; // ~30 days at 5s/ledger
 const LEDGER_BUMP: u32 = 535680; // ~31 days
 
@@ -370,6 +389,7 @@ impl PaymentStreamContract {
         start_time: u64,
         end_time: u64,
     ) -> u64 {
+        sender.require_auth();
         Self::create_stream_internal(
             env,
             sender,
@@ -422,6 +442,7 @@ impl PaymentStreamContract {
         end_time: u64,
         cliff_duration: u64,
     ) -> u64 {
+        sender.require_auth();
         Self::create_stream_internal(
             env,
             sender,
@@ -433,6 +454,102 @@ impl PaymentStreamContract {
             end_time,
             cliff_duration,
         )
+    }
+
+    /// Create up to [`MAX_STREAMS_PER_BATCH`] recipient streams in a single
+    /// invocation (batch payroll).
+    ///
+    /// Every recipient's parameters are validated up front so that a single
+    /// invalid entry fails the whole batch atomically — no partial streams are
+    /// created. The `sender` address is authenticated once for the entire
+    /// batch.
+    ///
+    /// # Arguments
+    /// * `sender` - Address funding and authorizing the entire batch.
+    /// * `params` - Per-recipient stream parameters (max `MAX_STREAMS_PER_BATCH` entries).
+    ///
+    /// # Authorization
+    /// Requires the `sender` address to sign the call.
+    ///
+    /// # Errors
+    /// - `Error::EmptyBatch` - `params` is empty.
+    /// - `Error::BatchLimitExceeded` - `params` exceeds `MAX_STREAMS_PER_BATCH` entries.
+    /// - `Error::InvalidAmount` - any entry has `total_amount <= 0` or an out-of-range `initial_amount`.
+    /// - `Error::InvalidTimeRange` - any entry has `end_time <= start_time`.
+    /// - `Error::InvalidCliff` - any entry has `cliff_duration >= end_time - start_time`.
+    /// - `Error::ContractPaused` - the emergency circuit breaker is active.
+    ///
+    /// # Returns
+    /// The stream IDs of the newly created streams, in batch order.
+    pub fn create_batch_streams(
+        env: Env,
+        sender: Address,
+        params: Vec<StreamParams>,
+    ) -> Vec<u64> {
+        Self::assert_not_paused(&env);
+        // The sender authorises the entire batch exactly once.
+        sender.require_auth();
+
+        let count = params.len();
+        if count == 0 {
+            panic_with_error!(&env, Error::EmptyBatch);
+        }
+        if count > MAX_STREAMS_PER_BATCH {
+            panic_with_error!(&env, Error::BatchLimitExceeded);
+        }
+
+        // Validate the entire batch before creating anything so a single bad
+        // entry reverts the whole call (no partial payroll streams).
+        for p in params.iter() {
+            Self::validate_stream_params(
+                &env,
+                p.total_amount,
+                p.initial_amount,
+                p.start_time,
+                p.end_time,
+                p.cliff_duration,
+            );
+        }
+
+        let mut ids: Vec<u64> = Vec::new(&env);
+        for p in params.iter() {
+            let id = Self::create_stream_internal(
+                env.clone(),
+                sender.clone(),
+                p.recipient.clone(),
+                p.token.clone(),
+                p.total_amount,
+                p.initial_amount,
+                p.start_time,
+                p.end_time,
+                p.cliff_duration,
+            );
+            ids.push_back(id);
+        }
+        ids
+    }
+
+    /// Validate a stream parameter set, panicking on any invalid input.
+    fn validate_stream_params(
+        env: &Env,
+        total_amount: i128,
+        initial_amount: i128,
+        start_time: u64,
+        end_time: u64,
+        cliff_duration: u64,
+    ) {
+        if total_amount <= 0 {
+            panic_with_error!(env, Error::InvalidAmount);
+        }
+        if initial_amount < 0 || initial_amount > total_amount {
+            panic_with_error!(env, Error::InvalidAmount);
+        }
+        if end_time <= start_time {
+            panic_with_error!(env, Error::InvalidTimeRange);
+        }
+        if cliff_duration >= end_time - start_time {
+            panic_with_error!(env, Error::InvalidCliff);
+        }
     }
 
     /// Shared implementation for stream creation.
@@ -448,7 +565,6 @@ impl PaymentStreamContract {
         cliff_duration: u64,
     ) -> u64 {
         Self::assert_not_paused(&env);
-        sender.require_auth();
 
         // Validate inputs
         if total_amount <= 0 {

--- a/contracts/payment-stream/src/test.rs
+++ b/contracts/payment-stream/src/test.rs
@@ -1,9 +1,8 @@
 #[cfg(test)]
 mod test {
-    use super::*;
     use soroban_sdk::testutils::{Address as _, Events, Ledger, MockAuth, MockAuthInvoke};
-    use soroban_sdk::{token, Address, Env, IntoVal};
-    use crate::{PaymentStreamContract, PaymentStreamContractClient, StreamStatus};
+    use soroban_sdk::{token, vec, Address, Env, IntoVal, Vec};
+    use crate::{PaymentStreamContract, PaymentStreamContractClient, StreamParams, StreamStatus};
 
 
     
@@ -2609,6 +2608,416 @@ fn test_withdraw_after_pause_and_resume() {
         // Advance to effective elapsed = 40 -> vested = 1000 * 40 / 100 = 400.
         env.ledger().set_timestamp(80);
         assert_eq!(client.withdrawable_amount(&stream_id), 400);
+    }
+
+    // -----------------------------------------------------------------------
+    // Batch stream creation (multi-recipient payroll) tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: build a batch of identical `StreamParams` for `recipients`.
+    fn batch_params(
+        env: &Env,
+        recipients: Vec<Address>,
+        token: &Address,
+        total: i128,
+        start: u64,
+        end: u64,
+        cliff: u64,
+    ) -> Vec<StreamParams> {
+        let mut params: Vec<StreamParams> = Vec::new(env);
+        for r in recipients.iter() {
+            params.push_back(StreamParams {
+                recipient: r,
+                token: token.clone(),
+                total_amount: total,
+                initial_amount: total,
+                start_time: start,
+                end_time: end,
+                cliff_duration: cliff,
+            });
+        }
+        params
+    }
+
+    /// A small batch creates one stream per recipient with sequential IDs.
+    #[test]
+    fn test_create_batch_streams() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let r1 = Address::generate(&env);
+        let r2 = Address::generate(&env);
+        let r3 = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &300);
+
+        let recipients = vec![&env, r1.clone(), r2.clone(), r3.clone()];
+        let params = batch_params(&env, recipients, &token, 100, 0, 100, 0);
+
+        let ids = client.create_batch_streams(&sender, &params);
+
+        assert_eq!(ids.len(), 3);
+        assert_eq!(ids.get(0).unwrap(), 1);
+        assert_eq!(ids.get(1).unwrap(), 2);
+        assert_eq!(ids.get(2).unwrap(), 3);
+
+        for id in 1..=3u64 {
+            let stream = client.get_stream(&id);
+            assert_eq!(stream.status, StreamStatus::Active);
+            assert_eq!(stream.total_amount, 100);
+        }
+
+        let token_client = token::Client::new(&env, &token);
+        assert_eq!(token_client.balance(&contract_id), 300);
+        assert_eq!(token_client.balance(&sender), 0);
+
+        let proto = client.get_protocol_metrics();
+        assert_eq!(proto.total_streams_created, 3);
+        assert_eq!(proto.total_active_streams, 3);
+    }
+
+    /// A full batch of 50 streams succeeds in one call.
+    #[test]
+    fn test_create_batch_streams_50() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        // A full 50-recipient payroll batch intentionally exceeds the
+        // conservative mainnet write-entry budget, so we disable the emulated
+        // invocation resource limits for this test.
+        env.cost_estimate().disable_resource_limits();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &500);
+
+        let mut recipients: Vec<Address> = Vec::new(&env);
+        for _ in 0..50 {
+            recipients.push_back(Address::generate(&env));
+        }
+        let params = batch_params(&env, recipients, &token, 10, 0, 100, 0);
+
+        let ids = client.create_batch_streams(&sender, &params);
+        assert_eq!(ids.len(), 50);
+
+        // IDs are sequential across the whole batch.
+        for i in 0..50u64 {
+            assert_eq!(ids.get(i as u32).unwrap(), i + 1);
+        }
+
+        let token_client = token::Client::new(&env, &token);
+        assert_eq!(token_client.balance(&contract_id), 500);
+    }
+
+    /// A single invalid entry reverts the entire batch — no partial streams.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #4)")]
+    fn test_create_batch_streams_invalid_entry_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let r1 = Address::generate(&env);
+        let r2 = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &300);
+
+        let mut params: Vec<StreamParams> = Vec::new(&env);
+        params.push_back(StreamParams {
+            recipient: r1.clone(),
+            token: token.clone(),
+            total_amount: 100,
+            initial_amount: 100,
+            start_time: 0,
+            end_time: 100,
+            cliff_duration: 0,
+        });
+        // Invalid: total_amount <= 0.
+        params.push_back(StreamParams {
+            recipient: r2,
+            token: token.clone(),
+            total_amount: 0,
+            initial_amount: 0,
+            start_time: 0,
+            end_time: 100,
+            cliff_duration: 0,
+        });
+
+        client.create_batch_streams(&sender, &params);
+    }
+
+    /// After a failed batch, no stream state or token movement remains.
+    #[test]
+    fn test_create_batch_streams_invalid_entry_leaves_no_state() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let r1 = Address::generate(&env);
+        let r2 = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &300);
+
+        let mut params: Vec<StreamParams> = Vec::new(&env);
+        params.push_back(StreamParams {
+            recipient: r1,
+            token: token.clone(),
+            total_amount: 100,
+            initial_amount: 100,
+            start_time: 0,
+            end_time: 100,
+            cliff_duration: 0,
+        });
+        params.push_back(StreamParams {
+            recipient: r2,
+            token: token.clone(),
+            total_amount: 0,
+            initial_amount: 0,
+            start_time: 0,
+            end_time: 100,
+            cliff_duration: 0,
+        });
+
+        // The batch call fails but must not create partial streams.
+        let result = client.try_create_batch_streams(&sender, &params);
+        assert!(result.is_err());
+
+        // Nothing was created and no tokens moved.
+        let proto = client.get_protocol_metrics();
+        assert_eq!(proto.total_streams_created, 0);
+        assert_eq!(proto.total_active_streams, 0);
+
+        let token_client = token::Client::new(&env, &token);
+        assert_eq!(token_client.balance(&contract_id), 0);
+        assert_eq!(token_client.balance(&sender), 300);
+    }
+
+    /// Batches larger than the maximum are rejected.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #24)")]
+    fn test_create_batch_streams_over_limit() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &600);
+
+        let mut recipients: Vec<Address> = Vec::new(&env);
+        for _ in 0..51 {
+            recipients.push_back(Address::generate(&env));
+        }
+        let params = batch_params(&env, recipients, &token, 10, 0, 100, 0);
+
+        client.create_batch_streams(&sender, &params);
+    }
+
+    /// An empty batch is rejected.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #25)")]
+    fn test_create_batch_streams_empty() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let params: Vec<StreamParams> = Vec::new(&env);
+        client.create_batch_streams(&sender, &params);
+    }
+
+    /// A non-sender caller cannot create a batch.
+    #[test]
+    #[should_panic(expected = "Unauthorized")]
+    fn test_create_batch_streams_unauthorized() {
+        let env = Env::default();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "initialize",
+                args: (&admin, &fee_collector, &0u32).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client.initialize(&admin, &fee_collector, &0);
+
+        let mut params: Vec<StreamParams> = Vec::new(&env);
+        params.push_back(StreamParams {
+            recipient,
+            token: token.clone(),
+            total_amount: 100,
+            initial_amount: 100,
+            start_time: 0,
+            end_time: 100,
+            cliff_duration: 0,
+        });
+
+        // Only the attacker (not the sender) authorises the batch call.
+        env.mock_auths(&[MockAuth {
+            address: &attacker,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "create_batch_streams",
+                args: (&attacker, &params).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+
+        client.create_batch_streams(&attacker, &params);
+    }
+
+    /// Batch creation is blocked while the emergency circuit breaker is active.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #17)")]
+    fn test_create_batch_streams_blocked_when_paused() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &100);
+
+        client.emergency_pause();
+
+        let mut params: Vec<StreamParams> = Vec::new(&env);
+        params.push_back(StreamParams {
+            recipient,
+            token: token.clone(),
+            total_amount: 100,
+            initial_amount: 100,
+            start_time: 0,
+            end_time: 100,
+            cliff_duration: 0,
+        });
+
+        client.create_batch_streams(&sender, &params);
+    }
+
+    /// Batch streams can carry per-recipient cliff periods.
+    #[test]
+    fn test_create_batch_streams_with_cliff() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let r1 = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &1000);
+
+        let recipients = vec![&env, r1.clone()];
+        let params = batch_params(&env, recipients, &token, 1000, 0, 100, 30);
+
+        let ids = client.create_batch_streams(&sender, &params);
+        assert_eq!(ids.len(), 1);
+
+        let stream = client.get_stream(&ids.get(0).unwrap());
+        assert_eq!(stream.cliff_duration, 30);
+
+        // Inside the cliff nothing is withdrawable.
+        env.ledger().set_timestamp(10);
+        assert_eq!(client.withdrawable_amount(&ids.get(0).unwrap()), 0);
+
+        // Past the cliff, linear vesting resumes.
+        env.ledger().set_timestamp(50);
+        assert_eq!(client.withdrawable_amount(&ids.get(0).unwrap()), 500);
     }
 
 }

--- a/contracts/payment-stream/src/test.rs
+++ b/contracts/payment-stream/src/test.rs
@@ -1916,7 +1916,7 @@ fn test_withdraw_after_pause_and_resume() {
         client.emergency_pause();
 
         let events = env.events().all();
-        assert!(events.len() > 0);
+        assert!(events.events().len() > 0);
     }
 
     /// `emergency_unpause` emits the correct event.
@@ -1930,7 +1930,7 @@ fn test_withdraw_after_pause_and_resume() {
         client.emergency_unpause();
 
         let events = env.events().all();
-        assert!(events.len() > 0);
+        assert!(events.events().len() > 0);
     }
 
     /// Double-pause is rejected with `AlreadyPaused` (error code 18).
@@ -2195,5 +2195,420 @@ fn test_withdraw_after_pause_and_resume() {
 
         assert!(client.is_paused());
     }
-    
+
+    // -----------------------------------------------------------------------
+    // Cliff-period linear vesting tests
+    // -----------------------------------------------------------------------
+
+    /// A stream created with a cliff stores and reports the cliff duration.
+    #[test]
+    fn test_create_stream_with_cliff() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &1000);
+
+        let stream_id = client.create_stream_with_cliff(
+            &sender,
+            &recipient,
+            &token,
+            &1000,
+            &1000,
+            &0,
+            &100,
+            &10,
+        );
+
+        assert_eq!(stream_id, 1);
+
+        let stream = client.get_stream(&stream_id);
+        assert_eq!(stream.cliff_duration, 10);
+        assert_eq!(stream.total_amount, 1000);
+        assert_eq!(stream.status, StreamStatus::Active);
+    }
+
+    /// A plain `create_stream` always reports a zero cliff duration, preserving
+    /// the legacy no-cliff behaviour.
+    #[test]
+    fn test_create_stream_cliff_duration_zero() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &1000);
+
+        let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &0, &100);
+
+        let stream = client.get_stream(&stream_id);
+        assert_eq!(stream.cliff_duration, 0);
+    }
+
+    /// Creating a stream whose cliff is not shorter than its duration is rejected.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #23)")]
+    fn test_create_stream_with_cliff_invalid() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &1000);
+
+        // cliff_duration (100) is not shorter than duration (100 - 0)
+        client.create_stream_with_cliff(&sender, &recipient, &token, &1000, &1000, &0, &100, &100);
+    }
+
+    /// Nothing is withdrawable while the clock is inside the cliff period.
+    #[test]
+    fn test_cliff_blocks_withdrawal_before_cliff() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &1000);
+
+        let stream_id = client.create_stream_with_cliff(
+            &sender,
+            &recipient,
+            &token,
+            &1000,
+            &1000,
+            &0,
+            &100,
+            &30,
+        );
+
+        env.ledger().set_timestamp(10);
+        assert_eq!(client.withdrawable_amount(&stream_id), 0);
+
+        env.ledger().set_timestamp(29);
+        assert_eq!(client.withdrawable_amount(&stream_id), 0);
+    }
+
+    /// Attempting a withdrawal while the clock is inside the cliff period is
+    /// rejected with `InsufficientWithdrawable`.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #10)")]
+    fn test_withdraw_before_cliff() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &1000);
+
+        let stream_id = client.create_stream_with_cliff(
+            &sender,
+            &recipient,
+            &token,
+            &1000,
+            &1000,
+            &0,
+            &100,
+            &30,
+        );
+
+        env.ledger().set_timestamp(10);
+        client.withdraw(&stream_id, &100);
+    }
+
+    /// At the exact cliff boundary the pro-rata share accrued during the cliff
+    /// becomes claimable.
+    #[test]
+    fn test_cliff_release_at_boundary() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &1000);
+
+        // 1000 tokens over 100 seconds with a 20-second cliff.
+        let stream_id = client.create_stream_with_cliff(
+            &sender,
+            &recipient,
+            &token,
+            &1000,
+            &1000,
+            &0,
+            &100,
+            &20,
+        );
+
+        // At t = 20 the pro-rata share (20/100 * 1000 = 200) is available.
+        env.ledger().set_timestamp(20);
+        assert_eq!(client.withdrawable_amount(&stream_id), 200);
+
+        // Withdraw that share.
+        client.withdraw(&stream_id, &200);
+
+        let stream = client.get_stream(&stream_id);
+        assert_eq!(stream.withdrawn_amount, 200);
+
+        let token_client = token::Client::new(&env, &token);
+        assert_eq!(token_client.balance(&recipient), 200);
+        assert_eq!(token_client.balance(&contract_id), 800);
+    }
+
+    /// After the cliff, the amount available grows linearly over the whole
+    /// vesting window.
+    #[test]
+    fn test_cliff_linear_vesting_after_cliff() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &1000);
+
+        // 1000 tokens over 100 seconds, cliff 20 seconds.
+        let stream_id = client.create_stream_with_cliff(
+            &sender,
+            &recipient,
+            &token,
+            &1000,
+            &1000,
+            &0,
+            &100,
+            &20,
+        );
+
+        // t=25 -> 250, t=50 -> 500, t=80 -> 800, t=100 -> 1000.
+        env.ledger().set_timestamp(25);
+        assert_eq!(client.withdrawable_amount(&stream_id), 250);
+
+        env.ledger().set_timestamp(50);
+        assert_eq!(client.withdrawable_amount(&stream_id), 500);
+
+        env.ledger().set_timestamp(80);
+        assert_eq!(client.withdrawable_amount(&stream_id), 800);
+
+        env.ledger().set_timestamp(100);
+        assert_eq!(client.withdrawable_amount(&stream_id), 1000);
+    }
+
+    /// `withdraw_max` respects the cliff: rejected before, works after.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #10)")]
+    fn test_withdraw_max_before_cliff() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &1000);
+
+        let stream_id = client.create_stream_with_cliff(
+            &sender,
+            &recipient,
+            &token,
+            &1000,
+            &1000,
+            &0,
+            &100,
+            &30,
+        );
+
+        env.ledger().set_timestamp(10);
+        client.withdraw_max(&stream_id);
+    }
+
+    /// Cancelling inside the cliff returns the full escrowed balance to the
+    /// sender because nothing has vested yet.
+    #[test]
+    fn test_cancel_before_cliff_refunds_full_balance() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &1000);
+
+        let stream_id = client.create_stream_with_cliff(
+            &sender,
+            &recipient,
+            &token,
+            &1000,
+            &1000,
+            &0,
+            &100,
+            &30,
+        );
+
+        env.ledger().set_timestamp(10);
+        client.cancel_stream(&stream_id);
+
+        let stream = client.get_stream(&stream_id);
+        assert_eq!(stream.status, StreamStatus::Canceled);
+
+        let token_client = token::Client::new(&env, &token);
+        assert_eq!(token_client.balance(&sender), 1000);
+        assert_eq!(token_client.balance(&contract_id), 0);
+    }
+
+    /// Pausing a stream inside its cliff keeps the effective elapsed time
+    /// stopped, so the cliff must still elapse after the pause is lifted.
+    #[test]
+    fn test_cliff_with_pause_and_resume() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let fee_collector = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = sac.address();
+
+        let contract_id = env.register(PaymentStreamContract, ());
+        let client = PaymentStreamContractClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &fee_collector, &0);
+
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&sender, &1000);
+
+        // 1000 over 100s, cliff 30s.
+        let stream_id = client.create_stream_with_cliff(
+            &sender,
+            &recipient,
+            &token,
+            &1000,
+            &1000,
+            &0,
+            &100,
+            &30,
+        );
+
+        // Vest 20s, then pause for 40s.
+        env.ledger().set_timestamp(20);
+        client.pause_stream(&stream_id);
+
+        env.ledger().set_timestamp(60);
+        assert_eq!(client.withdrawable_amount(&stream_id), 0);
+
+        client.resume_stream(&stream_id);
+
+        // Resume: end_time extended by 40s (now 140). Effective elapsed =
+        // (current - start) - paused = (60 - 0) - 40 = 20, still below cliff 30.
+        assert_eq!(client.withdrawable_amount(&stream_id), 0);
+
+        // Advance to effective elapsed = 40 -> vested = 1000 * 40 / 100 = 400.
+        env.ledger().set_timestamp(80);
+        assert_eq!(client.withdrawable_amount(&stream_id), 400);
+    }
+
 }

--- a/docs/contracts/payment-stream.md
+++ b/docs/contracts/payment-stream.md
@@ -17,6 +17,7 @@ A struct that holds all the essential information about a single payment stream.
 -   `total_amount`: `i128` - The total amount of tokens to be streamed over the duration.
 -   `withdrawn_amount`: `i128` - The amount of tokens already withdrawn by the recipient.
 -   `start_time`: `u64` - The Unix timestamp marking the beginning of the stream.
+-   `cliff_duration`: `u64` - Seconds after `start_time` during which nothing is withdrawable (linear lockup). `0` means no cliff.
 -   `end_time`: `u64` - The Unix timestamp marking the end of the stream.
 -   `status`: `StreamStatus` - The current status of the stream.
 
@@ -50,6 +51,23 @@ Creates a new payment stream with the specified parameters.
 -   `start_time`: `u64` - The timestamp when the stream begins.
 -   `end_time`: `u64` - The timestamp when the stream ends.
 -   Returns: A `u64` representing the unique ID of the newly created stream.
+
+### `create_stream_with_cliff(env: Env, sender: Address, recipient: Address, token: Address, total_amount: i128, initial_amount: i128, start_time: u64, end_time: u64, cliff_duration: u64) -> u64`
+
+Creates a new payment stream with a cliff (linear lockup) period.
+
+-   `env`: The contract environment.
+-   `sender`: `Address` - The account funding the stream.
+-   `recipient`: `Address` - The account that will receive the funds.
+-   `token`: `Address` - The token to be streamed.
+-   `total_amount`: `i128` - The total amount to be streamed.
+-   `initial_amount`: `i128` - The amount transferred to the escrow on creation.
+-   `start_time`: `u64` - The timestamp when vesting begins.
+-   `end_time`: `u64` - The timestamp when vesting completes.
+-   `cliff_duration`: `u64` - Seconds after `start_time` during which nothing is withdrawable. Must be strictly shorter than `end_time - start_time`.
+-   Returns: A `u64` representing the unique ID of the newly created stream.
+
+> **Cliff semantics:** no tokens are withdrawable until `cliff_duration` seconds after `start_time`. Once the cliff passes, tokens vest linearly across the whole `[start_time, end_time]` window, so the pro-rata share accrued during the cliff becomes claimable immediately at the cliff boundary.
 
 ### `get_stream(env: Env, stream_id: u64) -> Option<Stream>`
 


### PR DESCRIPTION
## Summary

Adds `create_batch_streams` to `payment-stream`, letting a sender create up to **50 recipient streams in a single transaction** (batch payroll). Closes #511.

## What changed

- New `StreamParams` contracttype (`recipient`, `token`, `total_amount`, `initial_amount`, `start_time`, `end_time`, `cliff_duration`).
- `MAX_STREAMS_PER_BATCH = 50`.
- New errors: `BatchLimitExceeded = 24`, `EmptyBatch = 25`.
- `create_batch_streams(env, sender, params: Vec<StreamParams>) -> Vec<u64>`:
  - Authenticates the **sender exactly once** for the whole batch.
  - Rejects empty batches and batches > 50.
  - **Validates every entry up front** so a single invalid recipient reverts the entire call atomically — no partial streams are ever created.
  - Returns the created stream IDs in batch order.
- Refactor: `sender.require_auth()` moved out of `create_stream_internal` into the public entry points (`create_stream`, `create_stream_with_cliff`, `create_batch_streams`). Calling `require_auth` on the same sender more than once with a batch would otherwise raise `Error(Auth, ExistingValue)` ("frame is already authorized").

## Tests

9 new tests: 3-recipient batch, full 50-recipient batch, empty batch, over-limit batch, invalid-entry revert + no partial state, unauthorized caller, blocked-when-paused, per-recipient cliff.

**74 / 74 tests pass**; `cargo build -p payment-stream --release --target wasm32v1-none` clean.

## Note on the 50-recipient test

A full 50-recipient batch writes more ledger entries than the conservative mainnet invocation budget (`write_entries: 50`). The batch limit is a validation guard; real on-chain capacity depends on the resource fee. The 50-recipient test therefore calls `env.cost_estimate().disable_resource_limits()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional cliff periods for payment streams, delaying withdrawals until the cliff is reached.
  * Added batch creation for up to 50 streams, with per-stream cliff settings.
  * Added token swaps for deposits, including slippage and path validation.
  * Added configurable DEX routing.

* **Bug Fixes**
  * Improved pause enforcement and cliff-aware withdrawal calculations.

* **Documentation**
  * Documented cliff periods and the new stream creation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->