### PR TITLE
fix(web): gracefully handle connection modal user cancellation

### DIFF
--- a/apps/web/src/components/organisms/wallet-modal.test.tsx
+++ b/apps/web/src/components/organisms/wallet-modal.test.tsx
@@ -119,8 +119,8 @@ describe("WalletModal – rendering", () => {
 describe("WalletModal – wallet selection", () => {
   it("Connect Now button is disabled by default (no selection)", () => {
     renderModal();
-    const btn = screen.getByTestId("connect-now-button");
-    expect(btn).toBeDisabled();
+    const btn = screen.getByTestId("connect-now-button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
   });
 
   it("selecting a wallet marks it as aria-checked=true", () => {
@@ -141,7 +141,8 @@ describe("WalletModal – wallet selection", () => {
   it("enables the Connect Now button after a wallet is selected", () => {
     renderModal();
     fireEvent.click(screen.getByTestId("wallet-option-freighter"));
-    expect(screen.getByTestId("connect-now-button")).not.toBeDisabled();
+    const btn = screen.getByTestId("connect-now-button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
   });
 
   it("Space key selects a wallet", () => {
@@ -182,8 +183,8 @@ describe("WalletModal – connect action", () => {
     renderModal();
     expect(screen.getByText(/connecting/i)).toBeTruthy();
     // All wallet option buttons should be disabled
-    const radios = screen.getAllByRole("radio");
-    radios.forEach((r) => expect(r).toBeDisabled());
+    const radios = screen.getAllByRole("radio") as HTMLButtonElement[];
+    radios.forEach((r) => expect(r.disabled).toBe(true));
   });
 });
 

--- a/apps/web/src/components/organisms/wallet-modal.tsx
+++ b/apps/web/src/components/organisms/wallet-modal.tsx
@@ -1,9 +1,7 @@
 "use client";
-import { motion } from "framer-motion";
-import { Wallet, Check } from "lucide-react";
+import React from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Check, Loader2 } from "lucide-react";
-import React from "react";
 import { useWallet, WalletId } from "@/providers/StellarWalletProvider";
 import {
   Dialog,
@@ -126,13 +124,6 @@ export function WalletModal() {
     <Dialog open={isModalOpen} onOpenChange={(open) => !open && closeModal()}>
       <DialogContent
         onCloseAutoFocus={handleCloseAutoFocus}
-        className="max-w-md p-1 overflow-hidden border-white/10 bg-[#0F1621] rounded-3xl shadow-2xl"
-      >
-        {/* Glossy overlay effect */}
-        <div
-          aria-hidden="true"
-          className="absolute inset-0 bg-linear-to-br from-white/5 to-transparent pointer-events-none"
-        />
         className="w-full max-w-sm sm:max-w-md p-1 overflow-hidden border-white/10 bg-[#0F1621] rounded-3xl shadow-2xl mx-4 sm:mx-auto"
         aria-modal="true"
       >

--- a/apps/web/src/providers/StellarWalletProvider.test.tsx
+++ b/apps/web/src/providers/StellarWalletProvider.test.tsx
@@ -55,6 +55,8 @@ vi.mock("@/services/offramp.service", () => ({
 // Mock react-hot-toast (pulled in by notification util)
 vi.mock("react-hot-toast", () => ({ default: { error: vi.fn() } }));
 
+import toast from "react-hot-toast";
+
 // ---------------------------------------------------------------------------
 // Static import of the provider (after mocks are registered)
 // ---------------------------------------------------------------------------
@@ -327,6 +329,60 @@ describe("StellarWalletProvider – wallet state persistence on refresh", () => 
       expect(store["stellar_wallet_address"]).toBe(VALID_ADDRESS);
       expect(store["@fundable/web:selected_wallet"]).toBe(WALLET_ID);
       expect(store["stellar_wallet_network"]).toBe(WalletNetwork.TESTNET);
+    });
+
+    it("gracefully handles user cancellation / rejection without error notification", async () => {
+      mockGetAddress.mockRejectedValueOnce(new Error("User rejected"));
+
+      const { result } = renderHook(() => useWallet(), { wrapper: Wrapper });
+
+      await waitFor(() => expect(result.current.connectionStatus).toBe("idle"));
+
+      await act(async () => {
+        await result.current.connect(WALLET_ID);
+      });
+
+      expect(result.current.address).toBeNull();
+      expect(result.current.isConnected).toBe(false);
+      expect(result.current.connectionStatus).toBe("idle");
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it("gracefully handles Freighter cancellation code -4 silently", async () => {
+      mockGetAddress.mockRejectedValueOnce({
+        code: -4,
+        message: "The user rejected this request.",
+      });
+
+      const { result } = renderHook(() => useWallet(), { wrapper: Wrapper });
+
+      await waitFor(() => expect(result.current.connectionStatus).toBe("idle"));
+
+      await act(async () => {
+        await result.current.connect(WALLET_ID);
+      });
+
+      expect(result.current.address).toBeNull();
+      expect(result.current.isConnected).toBe(false);
+      expect(result.current.connectionStatus).toBe("idle");
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it("gracefully handles modal closed error silently", async () => {
+      mockGetAddress.mockRejectedValueOnce(new Error("User closed modal"));
+
+      const { result } = renderHook(() => useWallet(), { wrapper: Wrapper });
+
+      await waitFor(() => expect(result.current.connectionStatus).toBe("idle"));
+
+      await act(async () => {
+        await result.current.connect(WALLET_ID);
+      });
+
+      expect(result.current.address).toBeNull();
+      expect(result.current.isConnected).toBe(false);
+      expect(result.current.connectionStatus).toBe("idle");
+      expect(toast.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/providers/StellarWalletProvider.tsx
+++ b/apps/web/src/providers/StellarWalletProvider.tsx
@@ -20,7 +20,7 @@ import { isValidStellarAddress } from "@/utils/stellar-validation";
 
 import { offrampService } from "@/services/offramp.service";
 import { notify } from "@/utils/notification";
-import { isLockedWalletError } from "@/utils/wallet-errors";
+import { isLockedWalletError, isWalletCancellationError } from "@/utils/wallet-errors";
 
 export type WalletId = string;
 export type ConnectionStatus =
@@ -101,14 +101,6 @@ export const StellarWalletProvider = ({
   // All three pieces of state are derived from the same storage snapshot so
   // they are always consistent with one another.
   const [address, setAddress] = useState<string | null>(() => {
-    if (typeof window === 'undefined') return null;
-    const savedAddress = safeGetItem("stellar_wallet_address")?.toUpperCase();
-    const savedNetwork = safeGetItem("stellar_wallet_network");
-    console.log('Lazy init address:', { savedAddress, savedNetwork });
-    if (savedNetwork === WalletNetwork.TESTNET && savedAddress && isValidStellarAddress(savedAddress)) {
-      return savedAddress;
-    }
-    return null;
     return loadPersistedSession().address;
   });
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>(() => {
@@ -117,15 +109,6 @@ export const StellarWalletProvider = ({
     // correctly reflects the pending auto-reconnect verification.
     if (savedAddress && savedWalletId && savedNetwork) {
       return "connecting";
-    if (typeof window === 'undefined') return "idle";
-    const savedAddress = safeGetItem("stellar_wallet_address")?.toUpperCase();
-    const savedWalletId = safeGetItem("stellar_wallet_id");
-    const savedAddress = safeGetItem("stellar_wallet_address");
-    const savedWalletId = safeGetItem("@fundable/web:selected_wallet");
-    const savedNetwork = safeGetItem("stellar_wallet_network");
-    console.log('Lazy init connectionStatus:', { savedAddress, savedWalletId, savedNetwork });
-    if (savedAddress && isValidStellarAddress(savedAddress) && savedWalletId && savedNetwork === WalletNetwork.TESTNET) {
-      return "connected";
     }
     return "idle";
   });
@@ -136,17 +119,6 @@ export const StellarWalletProvider = ({
     // Restore the network that was active when the user last connected so the
     // kit is initialised with the right network passphrase immediately.
     return loadPersistedSession().network ?? WalletNetwork.TESTNET;
-    if (typeof window === 'undefined') return null;
-    const savedAddress = safeGetItem("stellar_wallet_address")?.toUpperCase();
-    const savedWalletId = safeGetItem("stellar_wallet_id");
-    const savedAddress = safeGetItem("stellar_wallet_address");
-    const savedWalletId = safeGetItem("@fundable/web:selected_wallet");
-    const savedNetwork = safeGetItem("stellar_wallet_network");
-    console.log('Lazy init selectedWalletId:', { savedWalletId, savedNetwork });
-    if (savedNetwork === WalletNetwork.TESTNET && savedAddress && isValidStellarAddress(savedAddress)) {
-      return savedWalletId as WalletId | null;
-    }
-    return null;
   });
   const [kit, setKit] = useState<StellarWalletsKit | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -172,12 +144,6 @@ export const StellarWalletProvider = ({
     // here we confirm the extension responds and either promote to "connected"
     // or clear stale state when it no longer does.
     const { address: savedAddress, walletId: savedWalletId, network: savedNetwork } = loadPersistedSession();
-    // RESTORE SESSION
-    const savedAddress = safeGetItem("stellar_wallet_address")?.toUpperCase();
-    const savedWalletId = safeGetItem("stellar_wallet_id");
-    const savedAddress = safeGetItem("stellar_wallet_address");
-    const savedWalletId = safeGetItem("@fundable/web:selected_wallet");
-    const savedNetwork = safeGetItem("stellar_wallet_network");
 
     if (savedAddress && savedWalletId && savedNetwork) {
       if (savedNetwork !== network) {
@@ -354,6 +320,12 @@ export const StellarWalletProvider = ({
       else if (error && typeof error === "object" && "message" in error)
         errorMessage = String((error as { message: unknown }).message);
 
+      // Gracefully handle user cancellation / closing modal silently without console error or toast
+      if (isWalletCancellationError(error) || isWalletCancellationError({ message: errorMessage })) {
+        setConnectionStatus("idle");
+        return;
+      }
+
       if (isLockedWalletError(error) || isLockedWalletError({ message: errorMessage })) {
         notify.error(
           "Your wallet extension is locked. Unlock it and try connecting again.",
@@ -384,11 +356,6 @@ export const StellarWalletProvider = ({
             )}
           </div>,
         );
-      } else if (
-        errorMessage.toLowerCase().includes("user rejected") ||
-        errorMessage.toLowerCase().includes("permission denied")
-      ) {
-        notify.error("Connection rejected by user");
       } else {
         // Show a generic but helpful error for other errors
         notify.error(`Failed to connect to ${walletId}: ${errorMessage}`);

--- a/apps/web/src/utils/wallet-errors.test.ts
+++ b/apps/web/src/utils/wallet-errors.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   isLockedWalletError,
   WALLET_LOCKED_ERROR_CODE,
+  isWalletCancellationError,
+  WALLET_REJECTED_ERROR_CODE,
 } from "./wallet-errors";
 
 describe("isLockedWalletError", () => {
@@ -53,3 +55,43 @@ describe("isLockedWalletError", () => {
     expect(isLockedWalletError(undefined)).toBe(false);
   });
 });
+
+describe("isWalletCancellationError", () => {
+  it("detects user rejection error code -4", () => {
+    expect(
+      isWalletCancellationError({
+        code: WALLET_REJECTED_ERROR_CODE,
+        message: "The user rejected this request.",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects string user rejected / declined error messages", () => {
+    expect(isWalletCancellationError("User rejected")).toBe(true);
+    expect(isWalletCancellationError("User declined the connection request")).toBe(true);
+    expect(isWalletCancellationError("Permission denied")).toBe(true);
+  });
+
+  it("detects modal / popover closed or cancelled errors", () => {
+    expect(isWalletCancellationError(new Error("User closed modal"))).toBe(true);
+    expect(isWalletCancellationError(new Error("Connection request cancelled by user"))).toBe(true);
+    expect(isWalletCancellationError(new Error("Popup closed"))).toBe(true);
+    expect(isWalletCancellationError(new Error("Window closed"))).toBe(true);
+    expect(isWalletCancellationError({ message: "Modal closed by user" })).toBe(true);
+    expect(isWalletCancellationError({ error: { message: "Request aborted" } })).toBe(true);
+  });
+
+  it("detects string-coded cancellation errors", () => {
+    expect(isWalletCancellationError({ code: "USER_REJECTED" })).toBe(true);
+    expect(isWalletCancellationError({ code: "USER_CANCELLED" })).toBe(true);
+    expect(isWalletCancellationError({ code: "CANCELED" })).toBe(true);
+  });
+
+  it("does not treat genuine network or unhandled errors as cancellation", () => {
+    expect(isWalletCancellationError(new Error("Network connection failed"))).toBe(false);
+    expect(isWalletCancellationError(new Error("Internal RPC error"))).toBe(false);
+    expect(isWalletCancellationError(null)).toBe(false);
+    expect(isWalletCancellationError(undefined)).toBe(false);
+  });
+});
+

--- a/apps/web/src/utils/wallet-errors.ts
+++ b/apps/web/src/utils/wallet-errors.ts
@@ -44,3 +44,74 @@ export function isLockedWalletError(error: unknown): boolean {
 
   return false;
 }
+
+/**
+ * Error code returned/thrown when a user explicitly rejects or cancels a
+ * wallet connection or signing request (e.g. Freighter rejection code -4).
+ */
+export const WALLET_REJECTED_ERROR_CODE = -4;
+
+/**
+ * Returns true when an error indicates that the user cancelled or closed the
+ * wallet connection modal, popover, or extension prompt.
+ */
+export function isWalletCancellationError(error: unknown): boolean {
+  if (!error) return false;
+
+  const err = error as WalletErrorLike;
+  const code = err.code ?? err.error?.code;
+  const message = String(err.message ?? err.error?.message ?? "").toLowerCase();
+
+  // Known rejection / cancellation error codes
+  if (
+    code === WALLET_REJECTED_ERROR_CODE ||
+    code === -4 ||
+    code === "USER_REJECTED" ||
+    code === "USER_CANCELLED" ||
+    code === "USER_CANCELED" ||
+    code === "CANCELLED" ||
+    code === "CANCELED"
+  ) {
+    return true;
+  }
+
+  if (
+    message.includes("user rejected") ||
+    message.includes("user declined") ||
+    message.includes("declined") ||
+    message.includes("permission denied") ||
+    message.includes("user cancelled") ||
+    message.includes("user canceled") ||
+    message.includes("cancelled") ||
+    message.includes("canceled") ||
+    message.includes("cancellation") ||
+    message.includes("closed") ||
+    message.includes("dismissed") ||
+    message.includes("aborted") ||
+    message.includes("rejected")
+  ) {
+    return true;
+  }
+
+  if (typeof error === "string") {
+    const lower = error.toLowerCase();
+    return (
+      lower.includes("user rejected") ||
+      lower.includes("user declined") ||
+      lower.includes("declined") ||
+      lower.includes("permission denied") ||
+      lower.includes("user cancelled") ||
+      lower.includes("user canceled") ||
+      lower.includes("cancelled") ||
+      lower.includes("canceled") ||
+      lower.includes("cancellation") ||
+      lower.includes("closed") ||
+      lower.includes("dismissed") ||
+      lower.includes("aborted") ||
+      lower.includes("rejected")
+    );
+  }
+
+  return false;
+}
+


### PR DESCRIPTION
## Overview
Gracefully handles user cancellation or closing of the wallet connection modal/popover without throwing unhandled promise rejections, logging console errors, or firing error notifications.

## Related Issue
Closes #385

## Changes
### Web Application / Wallet Integration
* **[MODIFY]** `apps/web/src/utils/wallet-errors.ts`
  * Added `WALLET_REJECTED_ERROR_CODE` and `isWalletCancellationError` to identify user rejection, cancellation, and modal closure.
* **[MODIFY]** `apps/web/src/providers/StellarWalletProvider.tsx`
  * Catch cancellation exceptions via `isWalletCancellationError` in the `connect` catch block, silently resetting `connectionStatus` to `idle` without logging console errors or displaying error toasts.
* **[MODIFY]** `apps/web/src/components/organisms/wallet-modal.tsx`
  * Cleaned up duplicate imports and DialogContent JSX structure.
* **[MODIFY]** `apps/web/src/utils/wallet-errors.test.ts`
  * Added unit tests for `isWalletCancellationError`.
* **[MODIFY]** `apps/web/src/providers/StellarWalletProvider.test.tsx`
  * Added unit tests verifying silent handling of user cancellation, rejection, and modal closure.
* **[MODIFY]** `apps/web/src/components/organisms/wallet-modal.test.tsx`
  * Updated assertions to standard DOM disabled checks.

## Verification Results
```text
✓ src/utils/wallet-errors.test.ts (10 tests) 3ms
✓ src/components/molecules/WalletStatus.test.tsx (4 tests) 97ms
✓ src/components/organisms/wallet-modal.test.tsx (19 tests) 201ms
✓ src/providers/StellarWalletProvider.test.tsx (16 tests) 409ms

Test Files  4 passed (4)
Tests  49 passed (49)
```

| Acceptance Criteria | Status |
| :--- | :--- |
| Issue is resolved in `apps/web/src/providers/StellarWalletProvider.tsx:150-165` | ✅ Handled user cancellation silently without console error |
| No regression introduced in existing test suites | ✅ All 49 wallet tests passing |
