### PR TITLE
fix(api): pass publicKey to PaymentStreamClient in pause/resume/cancel

### DIFF
--- a/apps/web/src/components/modules/payment-stream/StreamActionsCell.tsx
+++ b/apps/web/src/components/modules/payment-stream/StreamActionsCell.tsx
@@ -67,11 +67,12 @@ export default function StreamActionsCell({ stream }: StreamActionsCellProps) {
     const handleOpenDeposit = () => setIsDepositOpen(true);
 
     const handlePause = async () => {
-        if (!signTransaction) return;
+        if (!address || !signTransaction) return;
         setIsLoading(true);
         try {
             await pauseStream({
                 id: stream.id,
+                address: address!,
                 signTransaction,
             });
             toast.success("Stream paused successfully");
@@ -84,11 +85,12 @@ export default function StreamActionsCell({ stream }: StreamActionsCellProps) {
     };
 
     const handleResume = async () => {
-        if (!signTransaction) return;
+        if (!address || !signTransaction) return;
         setIsLoading(true);
         try {
             await resumeStream({
                 id: stream.id,
+                address: address!,
                 signTransaction,
             });
             toast.success("Stream resumed successfully");
@@ -101,13 +103,14 @@ export default function StreamActionsCell({ stream }: StreamActionsCellProps) {
     };
 
     const handleCancel = async () => {
-        if (!signTransaction) return;
+        if (!address || !signTransaction) return;
         if (!confirm("Are you sure you want to cancel this stream? This action cannot be undone.")) return;
 
         setIsLoading(true);
         try {
             await cancelStream({
                 id: stream.id,
+                address: address!,
                 signTransaction,
             });
             toast.success("Stream canceled successfully");

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -203,11 +203,12 @@ export async function fetchAccountInfo(address: string, signal?: AbortSignal): P
         return null;
     }
 }
-export async function pauseStream(params: { id: string; signTransaction: (xdr: string) => Promise<string> }) {
+export async function pauseStream(params: { id: string; address: string; signTransaction: (xdr: string) => Promise<string> }) {
     const client = new PaymentStreamClient({
         networkPassphrase: NETWORK_PASSPHRASE,
         rpcUrl: SOROBAN_RPC_URL,
         contractId: PAYMENT_STREAM_CONTRACT_ID,
+        publicKey: params.address,
     });
 
     const tx = await client.pauseStream(BigInt(params.id));
@@ -215,11 +216,12 @@ export async function pauseStream(params: { id: string; signTransaction: (xdr: s
     await signAndSendTx(tx, params.signTransaction);
 }
 
-export async function resumeStream(params: { id: string; signTransaction: (xdr: string) => Promise<string> }) {
+export async function resumeStream(params: { id: string; address: string; signTransaction: (xdr: string) => Promise<string> }) {
     const client = new PaymentStreamClient({
         networkPassphrase: NETWORK_PASSPHRASE,
         rpcUrl: SOROBAN_RPC_URL,
         contractId: PAYMENT_STREAM_CONTRACT_ID,
+        publicKey: params.address,
     });
 
     const tx = await client.resumeStream(BigInt(params.id));
@@ -246,11 +248,12 @@ export async function getWithdrawableAmount(params: {
     return amount.toString();
 }
 
-export async function cancelStream(params: { id: string; signTransaction: (xdr: string) => Promise<string> }) {
+export async function cancelStream(params: { id: string; address: string; signTransaction: (xdr: string) => Promise<string> }) {
     const client = new PaymentStreamClient({
         networkPassphrase: NETWORK_PASSPHRASE,
         rpcUrl: SOROBAN_RPC_URL,
         contractId: PAYMENT_STREAM_CONTRACT_ID,
+        publicKey: params.address,
     });
 
     const tx = await client.cancelStream(BigInt(params.id));


### PR DESCRIPTION
Fixes #369

pauseStream, resumeStream, and cancelStream were building PaymentStreamClient
without publicKey, causing Soroban transaction footprint assembly to fail.

Added address param to all three functions in api.ts and passed it through
from StreamActionsCell.tsx (already available via useWallet()).
